### PR TITLE
Bug fix

### DIFF
--- a/cayleypy/cayley_graph_test.py
+++ b/cayleypy/cayley_graph_test.py
@@ -297,6 +297,12 @@ def test_generator_names():
     assert graph.generator_names == ["L", "R", "X"]
 
 
+def test_bfs_small_hash_chunk_size():
+    graph = prepare_graph("lrx", n=20)
+    graph = CayleyGraph(graph.generators, hash_chunk_size=100)
+    assert graph.bfs(max_diameter=8).layer_sizes == [1, 3, 6, 12, 24, 48, 91, 172, 325]
+
+
 # Below is the benchmark code. To tun: `BENCHMARK=1 pytest . -k benchmark`
 @pytest.mark.skipif(not BENCHMARK_RUN, reason="benchmark")
 @pytest.mark.parametrize("benchmark_mode", ["baseline", "bit_encoded", "bfs_numpy"])

--- a/cayleypy/hasher.py
+++ b/cayleypy/hasher.py
@@ -34,12 +34,12 @@ class StateHasher:
         if states.shape[0] <= self.chunk_size:
             return (states @ self.vec_hasher).reshape(-1)
         else:
-            parts = int(math.ceil(self.chunk_size / states.shape[0]))
-            return torch.hstack([z @ self.vec_hasher for z in torch.tensor_split(states, parts)]).reshape(-1)
+            parts = int(math.ceil(states.shape[0] / self.chunk_size))
+            return torch.vstack([z @ self.vec_hasher for z in torch.tensor_split(states, parts)]).reshape(-1)
 
     def _make_hashes_older_gpu(self, states: torch.Tensor) -> torch.Tensor:
         if states.shape[0] <= self.chunk_size:
             return torch.sum(states * self.vec_hasher, dim=1)
         else:
-            parts = int(math.ceil(self.chunk_size / states.shape[0]))
+            parts = int(math.ceil(states.shape[0] / self.chunk_size))
             return torch.hstack([torch.sum(z * self.vec_hasher, dim=1) for z in torch.tensor_split(states, parts)])

--- a/cayleypy/hasher.py
+++ b/cayleypy/hasher.py
@@ -35,7 +35,7 @@ class StateHasher:
             return (states @ self.vec_hasher).reshape(-1)
         else:
             parts = int(math.ceil(self.chunk_size / states.shape[0]))
-            return torch.hstack([z @ self.vec_hasher for z in torch.tensor_split(states, parts)])
+            return torch.hstack([z @ self.vec_hasher for z in torch.tensor_split(states, parts)]).reshape(-1)
 
     def _make_hashes_older_gpu(self, states: torch.Tensor) -> torch.Tensor:
         if states.shape[0] <= self.chunk_size:


### PR DESCRIPTION
* When doing batching, we need to make sure that result is 1-dimensional tensor, because by convension hases are 1-dimensional tensores. Adding reshape(-1) is cheap because it doesn't copy any data, just creates another view onto the same tensor.
* Also changed how `parts` is computed because before it was not doing any batching.