### PR TITLE
Anton naumov/fix bug bfs with max diamter hashes counting

### DIFF
--- a/cayleypy/bfs_result.py
+++ b/cayleypy/bfs_result.py
@@ -62,7 +62,7 @@ class BfsResult:
         """Dictionary used to remap vertex hashes to indexes."""
         n = self.num_vertices
         assert self.vertices_hashes is not None, "Run bfs with return_all_hashes=True."
-        assert len(self.vertices_hashes) == n
+        assert len(self.vertices_hashes) == n, "Number of vertices hashes must be the same as the number of veritces"
         ans: dict[int, int] = dict()
         for i in range(n):
             ans[int(self.vertices_hashes[i])] = i

--- a/cayleypy/cayley_graph.py
+++ b/cayleypy/cayley_graph.py
@@ -274,7 +274,7 @@ class CayleyGraph:
             layer0_hashes, layer1_hashes = layer1_hashes, layer2_hashes
             keep_alive_func()
         
-        if return_all_hashes:
+        if return_all_hashes and not full_graph_explored:
             all_layers_hashes.append(layer1_hashes)
 
         if not full_graph_explored and self.verbose > 0:

--- a/cayleypy/cayley_graph.py
+++ b/cayleypy/cayley_graph.py
@@ -273,6 +273,9 @@ class CayleyGraph:
             layer1 = layer2
             layer0_hashes, layer1_hashes = layer1_hashes, layer2_hashes
             keep_alive_func()
+        
+        if return_all_hashes:
+            all_layers_hashes.append(layer1_hashes)
 
         if not full_graph_explored and self.verbose > 0:
             print("BFS stopped before graph was fully explored.")


### PR DESCRIPTION
Fixed the hashes list in `bfs()` in for the case of not fully explored graph. If `bfs` was terminated before the exploration added --eg  `max_diameter` condition is triggered -- the last batch of hashses wasn't added to `all_layers_hashes`. The function itself was throwing no exception, but if `to_networx_graph()` was called after that an empty assertion was thrown:

```python
results = graph.bfs(return_all_edges=True, return_all_hashes=True, max_layer_size_to_explore=10)

# some assertion is triggered :(
results.to_networkx_graph()
...
File /usr/local/lib/python3.10/site-packages/cayleypy/bfs_result.py:65, in BfsResult.hashes_to_indices_dict(self)
     63 n = self.num_vertices
     64 assert self.vertices_hashes is not None, "Run bfs with return_all_hashes=True."
---> 65 assert len(self.vertices_hashes) == n
     66 ans: dict[int, int] = dict()
     67 for i in range(n):

AssertionError: 
```

Please take a look if everything is alright, I am not really familiar with this repo yet :)

Runned the tests like this, `74 passed, 3 skipped`:

```bash
CUDA_VISIBLE_DEVICES=-1 FAST=0 pytest 
```


