### PR TITLE
Make adjacency matrix symmetric even if BFS stopped early

### DIFF
--- a/cayleypy/cayley_graph.py
+++ b/cayleypy/cayley_graph.py
@@ -252,7 +252,7 @@ class CayleyGraph:
                     if self.string_encoder is None and self.definition.is_permutation_group():
                         edges_list_starts.append(layer1_hashes.repeat_interleave(self.definition.n_generators))
                     else:
-                        edges_list_starts += [layer1_hashes] * self.definition.n_generators
+                        edges_list_starts += [layer1_hashes.repeat(self.definition.n_generators)]
                     edges_list_ends.append(layer1_neighbors_hashes)
 
                 layer2, layer2_hashes, _ = self.get_unique_states(layer1_neighbors, hashes=layer1_neighbors_hashes)
@@ -289,6 +289,12 @@ class CayleyGraph:
 
         edges_list_hashes: Optional[torch.Tensor] = None
         if return_all_edges:
+            if not full_graph_explored:
+                # Add copy of edges between last 2 layers, but in opposite direction.
+                # This is done so adjacency matrix is symmetric.
+                v1, v2 = edges_list_starts[-1], edges_list_ends[-1]
+                edges_list_starts.append(v2)
+                edges_list_ends.append(v1)
             edges_list_hashes = torch.vstack([torch.hstack(edges_list_starts), torch.hstack(edges_list_ends)]).T
         vertices_hashes: Optional[torch.Tensor] = None
         if return_all_hashes:

--- a/cayleypy/cayley_graph_test.py
+++ b/cayleypy/cayley_graph_test.py
@@ -334,6 +334,13 @@ def test_bfs_heisenberg_group():
     assert bfs_result.layer_sizes == [1, 4, 12, 36, 82, 164, 294, 476, 724, 1052, 1464, 1972, 2590, 3324, 4186, 5188]
 
 
+def test_incomplete_bfs_symmetric_adjacency_matrix():
+    graph = CayleyGraph(prepare_graph("pyraminx"), device="cpu")
+    bfs_result = graph.bfs(return_all_edges=True, return_all_hashes=True, max_diameter=2)
+    mx = bfs_result.adjacency_matrix()
+    assert np.array_equal(mx, mx.T)
+
+
 # Below is the benchmark code. To run: `BENCHMARK=1 pytest . -k benchmark`
 @pytest.mark.skipif(not BENCHMARK_RUN, reason="benchmark")
 @pytest.mark.parametrize("benchmark_mode", ["baseline", "bit_encoded", "bfs_numpy"])


### PR DESCRIPTION
* This is done by adding a copy of edges between last 2 layers, but in opposite direction.
* We know that these edges are guaranteed to exist because generators are inverse closed.