### PR TITLE
Implement random walks

### DIFF
--- a/cayleypy/cayley_graph_def.py
+++ b/cayleypy/cayley_graph_def.py
@@ -228,3 +228,7 @@ class CayleyGraphDef:
     def is_permutation_group(self):
         """Whether generators in this graph are permutations."""
         return self.generators_type == GeneratorType.PERMUTATION
+
+    def is_matrix_group(self):
+        """Whether generators in this graph are matrices."""
+        return self.generators_type == GeneratorType.MATRIX


### PR DESCRIPTION
* Requested in #62 
* Also unified how we do graph transitions. We now have `_apply_generator_batched` that applies generator with given index to a batch of state. All diversity of generator types (permutation/matrix) and their encodings is encapsulated here. BFS, random walks and beam search will all use this method (directly or via get_neigbors). This will allow us to easily add more genrator types in the future.