### PR TITLE
Rewrite Predictor

### DIFF
--- a/cayleypy/beam_search_result.py
+++ b/cayleypy/beam_search_result.py
@@ -10,6 +10,7 @@ class BeamSearchResult:
     path_found: bool  # Whether full graph was explored.
     path_length: int  # Distance of found path from start state to central state.
     path: Optional[list[int]]  # Path from start state to central state (edges are generator indexes), if requested.
+    debug_scores: dict[int, float]  # Scores achieved on each step.
     graph: CayleyGraphDef  # Definition of graph on which beam search was run.
 
     def __post_init__(self):

--- a/cayleypy/bfs_result.py
+++ b/cayleypy/bfs_result.py
@@ -227,6 +227,9 @@ class BfsResult:
     @cached_property
     def all_states(self) -> torch.Tensor:
         """Explicit states, ordered by index."""
+        assert len(self.layers) == len(
+            self.layer_sizes
+        ), f"Not all layers were stored. Re-run BFS with max_layer_size_to_store={max(self.layer_sizes)}"
         return torch.vstack([self.layers[i] for i in range(len(self.layer_sizes))])
 
     def get_edge_name(self, i1: int, i2: int) -> str:

--- a/cayleypy/cayley_graph.py
+++ b/cayleypy/cayley_graph.py
@@ -436,7 +436,7 @@ class CayleyGraph:
         self,
         *,
         start_state: Union[torch.Tensor, np.ndarray, list],
-        predictor: Predictor = Predictor.const(),
+        predictor: Optional[Predictor] = None,
         beam_width=1000,
         max_iterations=1000,
         return_path=False,
@@ -444,12 +444,15 @@ class CayleyGraph:
         """Tries to find a path from `start_state` to central state using Beam Search algorithm.
 
         :param start_state: State from which to star search.
-        :param predictor: A heuristic that estimates scores for states (lower score= closer to center).
+        :param predictor: A heuristic that estimates scores for states (lower score = closer to center).
+          Defaults to Hamming distance heuristic.
         :param beam_width: Width of the beam (how many "best" states we consider at each step".
         :param max_iterations: Maximum number of iterations before giving up.
         :param return_path: Whether to return parth (consumes much more memory if True).
         :return: BeamSearchResult containing found path length and 9optionally) the path itself.
         """
+        if predictor is None:
+            predictor = Predictor(self, "hamming")
         start_states = self.encode_states(start_state)
         layer1, layer1_hashes, _ = self.get_unique_states(start_states)
         all_layers_hashes = [layer1_hashes]

--- a/cayleypy/cayley_graph.py
+++ b/cayleypy/cayley_graph.py
@@ -456,7 +456,7 @@ class CayleyGraph:
         start_states = self.encode_states(start_state)
         layer1, layer1_hashes, _ = self.get_unique_states(start_states)
         all_layers_hashes = [layer1_hashes]
-        debug_scores = dict()  # type: dict[int, float]
+        debug_scores = {}  # type: dict[int, float]
 
         for i in range(max_iterations):
             if bool(isin_via_searchsorted(self.central_state_hash, layer1_hashes)):

--- a/cayleypy/cayley_graph_test.py
+++ b/cayleypy/cayley_graph_test.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 import torch
 
-from . import BeamSearchResult, Predictor
+from . import BeamSearchResult
 from .bfs_numpy import bfs_numpy
 from .cayley_graph import CayleyGraph
 from .cayley_graph_def import MatrixGenerator, CayleyGraphDef
@@ -406,17 +406,17 @@ def _scramble(graph: CayleyGraph, num_scrambles: int) -> torch.Tensor:
 
 def test_beam_search_lrx_few_steps():
     graph = CayleyGraph(PermutationGroups.lrx(5))
-    result0 = graph.beam_search(start_state=[0, 1, 2, 3, 4], predictor=Predictor.const())
+    result0 = graph.beam_search(start_state=[0, 1, 2, 3, 4])
     assert result0.path_found
     assert result0.path_length == 0
 
-    result1 = graph.beam_search(start_state=[1, 0, 2, 3, 4], predictor=Predictor.const(), return_path=True)
+    result1 = graph.beam_search(start_state=[1, 0, 2, 3, 4], return_path=True)
     assert result1.path_found
     assert result1.path_length == 1
     assert result1.path == [2]
     assert result1.get_path_as_string() == "X"
 
-    result2 = graph.beam_search(start_state=[4, 1, 0, 2, 3], predictor=Predictor.const(), return_path=True)
+    result2 = graph.beam_search(start_state=[4, 1, 0, 2, 3], return_path=True)
     assert result2.path_found
     assert result2.path_length == 2
     assert result2.path == [0, 2]
@@ -428,8 +428,7 @@ def test_beam_search_lrx_n8_random():
     graph = CayleyGraph(PermutationGroups.lrx(n))
     start_state = np.random.permutation(n)
 
-    predictor = Predictor.hamming(graph)
-    bs_result = graph.beam_search(start_state=start_state, beam_width=10**7, predictor=predictor, return_path=True)
+    bs_result = graph.beam_search(start_state=start_state, beam_width=10**7, return_path=True)
     assert bs_result.path_length <= 28
     _validate_beam_search_result(graph, start_state, bs_result)
 

--- a/cayleypy/predictor.py
+++ b/cayleypy/predictor.py
@@ -1,5 +1,6 @@
+import math
 import typing
-from abc import ABC, abstractmethod
+from typing import Callable
 
 import torch
 
@@ -7,43 +8,49 @@ if typing.TYPE_CHECKING:
     from .cayley_graph import CayleyGraph
 
 
-class Predictor(ABC):
-    """Abstract class representing a "black box" that estimates distance for states from central state."""
+def _hamming_distance(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+    return torch.sum((x != y), dim=1)
 
-    @abstractmethod
-    def estimate_distance_to_central_state(self, states: torch.Tensor) -> torch.Tensor:
-        """For each state in `states` returns estimated distance to central state.
 
-        :param states: int64 tensor of shape (n, state_size) with states for which we want to estimate distance.
-        :return: 1D tensor of length `n` with estimated distances (of any numeric type).
+class Predictor:
+    """Estimates distance from central state to given states."""
+
+    def __init__(self, graph: "CayleyGraph", models_or_heuristics):
+        """Initializes Predictor.
+
+        :param graph: Associated CayleyGraph object.
+        :param models_or_heuristics: One of the following:
+
+            - "const" - will use predictor that returns 0 for any state.
+            - "hamming" - will use Hamming distance from central state.
+            - ``torch.nn.Module`` - will use given neural network model.
+            - Any object that has "predict" method (e.g. sklearn models).
+            - Any callable object.
         """
+        self.graph = graph
+        self.predict = lambda x: x  # type: Callable[[torch.Tensor], torch.Tensor]
+
+        if models_or_heuristics == "zero":
+            self.predict = lambda x: torch.zeros((x.shape[0],))
+        elif models_or_heuristics == "hamming":
+            self.predict = lambda x: _hamming_distance(graph.central_state, x)
+        elif isinstance(models_or_heuristics, torch.nn.Module):
+            self.predict = models_or_heuristics
+            self.predict.eval()
+            self.predict.to(graph.device)
+        elif hasattr(models_or_heuristics, "predict"):
+            self.predict = models_or_heuristics.predict
+        elif hasattr(models_or_heuristics, "__call__"):
+            self.predict = models_or_heuristics
+        else:
+            raise ValueError(f"Unable to understand how to call {models_or_heuristics}")
 
     def __call__(self, states: torch.Tensor) -> torch.Tensor:
-        return self.estimate_distance_to_central_state(states)
-
-    @staticmethod
-    def const() -> "ConstPredictor":
-        """Always returns 0."""
-        return ConstPredictor()
-
-    @staticmethod
-    def hamming(graph: "CayleyGraph") -> "HammingPredictor":
-        """Heuristic predictor. Estimate is the number of different elements between estimated and central states."""
-        return HammingPredictor(graph)
-
-
-class ConstPredictor(Predictor):
-    """Always returns 0."""
-
-    def estimate_distance_to_central_state(self, states: torch.Tensor) -> torch.Tensor:
-        return torch.zeros((states.shape[0]))
-
-
-class HammingPredictor(Predictor):
-    """Heuristic predictor. Estimate is the number of different elements between estimated and central states."""
-
-    def __init__(self, graph: "CayleyGraph"):
-        self.central_sate = graph.central_state
-
-    def estimate_distance_to_central_state(self, states: torch.Tensor) -> torch.Tensor:
-        return torch.not_equal(self.central_sate, states).sum(dim=1)
+        num_batches = int(math.ceil(states.shape[0] / self.graph.batch_size))
+        if num_batches > 1:
+            ans = []  # type: list[torch.Tensor]
+            for batch in states.tensor_split(num_batches, dim=0):
+                ans.append(self.predict(batch))
+            return torch.hstack(ans)
+        else:
+            return self.predict(states)

--- a/cayleypy/predictor.py
+++ b/cayleypy/predictor.py
@@ -21,7 +21,7 @@ class Predictor:
         :param graph: Associated CayleyGraph object.
         :param models_or_heuristics: One of the following:
 
-            - "const" - will use predictor that returns 0 for any state.
+            - "zero" - will use predictor that returns 0 for any state.
             - "hamming" - will use Hamming distance from central state.
             - ``torch.nn.Module`` - will use given neural network model.
             - Any object that has "predict" method (e.g. sklearn models).

--- a/cayleypy/predictor_test.py
+++ b/cayleypy/predictor_test.py
@@ -8,7 +8,7 @@ from .predictor import Predictor
 def test_hamming_predictor():
     graph_def = PermutationGroups.lrx(5).with_central_state("01001")
     graph = CayleyGraph(graph_def, device="cpu")
-    predictor = Predictor.hamming(graph)
+    predictor = Predictor(graph, "hamming")
     states = torch.tensor(
         [
             [0, 0, 0, 0, 0],

--- a/cayleypy/torch_utils.py
+++ b/cayleypy/torch_utils.py
@@ -12,7 +12,7 @@ class TorchHashSet:
     """A set of int64 numbers, backed by one or more sorted tensors."""
 
     def __init__(self):
-        self.data = []  # type: list[torch.Tensor]
+        self.data = []
 
     def add_sorted_hashes(self, sorted_numbers: torch.Tensor):
         """IMPORTANT: Assumes that new numbers are sorted and do not appear in the set before."""


### PR DESCRIPTION
Now predictor supports torch neural networks.

Example usage: https://www.kaggle.com/code/fedimser/beam-search-with-cayleypy/log?scriptVersionId=248744299