### PR TITLE
Fixed bug in bfs results loading and updated the corresponding test

### DIFF
--- a/cayleypy/bfs_result.py
+++ b/cayleypy/bfs_result.py
@@ -114,10 +114,16 @@ class BfsResult:
             else:
                 edges_list_hashes = f["edges_list_hashes"][()]
 
+            layers_keys = {}
+            for k in f.keys():
+                if k.startswith("layer__"):
+                    layer_n = int(k.strip("layer__"))
+                    layers_keys[layer_n] = k
+
             loaded_result = BfsResult(
                 bfs_completed=bool(f["bfs_completed"][()]),
                 layer_sizes=layer_sizes,
-                layers={x: f[f"layer__{str(x)}"][()] for x in range(len(layer_sizes))},
+                layers={k: f[layer_key][()] for k, layer_key in layers_keys.items()},
                 edges_list_hashes=edges_list_hashes,
                 layers_hashes=layers_hashes,
                 graph=CayleyGraphDef.create(

--- a/cayleypy/bfs_result_test.py
+++ b/cayleypy/bfs_result_test.py
@@ -38,20 +38,20 @@ def test_bfs_result_eq():
 
 
 def test_bfs_result_save_load():
-    graph = CayleyGraph(PermutationGroups.lrx(5), device="cpu")
 
     with TemporaryDirectory() as temp_dir:
         temp_dir = Path(temp_dir)
-
-        for return_all_hashes in [True, False]:
-            for return_all_edges in [True, False]:
-                for max_diameter in [3, 1000000]:
-                    bfs_result = graph.bfs(
-                        return_all_edges=return_all_edges,
-                        return_all_hashes=return_all_hashes,
-                        max_diameter=max_diameter,
-                    )
-                    bfs_result.save(temp_dir / "bfs_result.h5")
-                    loaded_bfs_result = BfsResult.load(temp_dir / "bfs_result.h5")
-                    assert bfs_result.graph == loaded_bfs_result.graph
-                    assert bfs_result == loaded_bfs_result, "Original and loaded BfsResults must be the same."
+        for graph_def in [PermutationGroups.lrx(4), PermutationGroups.transposons(8)]:
+            graph = CayleyGraph(graph_def, device="cpu")
+            for return_all_hashes in [True, False]:
+                for return_all_edges in [True, False]:
+                    for max_diameter in [3, 1000000]:
+                        bfs_result = graph.bfs(
+                            return_all_edges=return_all_edges,
+                            return_all_hashes=return_all_hashes,
+                            max_diameter=max_diameter,
+                        )
+                        bfs_result.save(temp_dir / "bfs_result.h5")
+                        loaded_bfs_result = BfsResult.load(temp_dir / "bfs_result.h5")
+                        assert bfs_result.graph == loaded_bfs_result.graph
+                        assert bfs_result == loaded_bfs_result, "Original and loaded BfsResults must be the same."


### PR DESCRIPTION
Found a bug in BfsResult loading -- sometimes the not all layers computed during bfs were stored. That didn't happen in lrx(5) group which was used for testing, added the test for transposons(8) group.