### PR TITLE
Feature/adjacent generator constraints

### DIFF
--- a/cayleypy/algo/beam_search.py
+++ b/cayleypy/algo/beam_search.py
@@ -69,6 +69,7 @@ class BeamSearchAlgorithm:
         :param bfs_result_for_mitm: For "simple" mode, BfsResult with pre-computed neighborhood of central state
             for meet-in-the-middle optimization. Defaults to None.
         :param verbose: Verbosity level (0=quiet, 1=basic, 10=detailed, 100=profiling).
+        :param constraint_map: Map from generator index to a predicate function to exclude certain states.
         :return: BeamSearchResult containing found path length and (optionally) the path itself.
         """
         if constraint_map is None:
@@ -120,6 +121,7 @@ class BeamSearchAlgorithm:
             meet-in-the-middle modification of Beam Search. Beam search will terminate when any of states in that
             neighborhood is encountered. Defaults to None, which means no meet-in-the-middle (i.e. only search for the
             central state).
+        :param constraint_map: Map from generator index to a predicate function to exclude certain states.
         :return: BeamSearchResult containing found path length and (optionally) the path itself.
         """
         if constraint_map is None:
@@ -220,6 +222,7 @@ class BeamSearchAlgorithm:
         :param predictor: Predictor object for scoring states. If None, uses Hamming distance.
         :param batch_size: Batch size for model predictions.
         :param verbose: Verbosity level (0=quiet, 1=basic, 10=detailed, 100=profiling).
+        :param constraint_map: Map from generator index to a predicate function to exclude certain states.
         :return: BeamSearchResult with search results.
         """
         if constraint_map is None:

--- a/cayleypy/cayley_graph.py
+++ b/cayleypy/cayley_graph.py
@@ -189,7 +189,6 @@ class CayleyGraph:
 
     def get_neighbors(self, states: torch.Tensor) -> torch.Tensor:
         """Calculates all neighbors of `states` (in internal representation)."""
-        """Internal in ---> internal out"""
         states_num = states.shape[0]
         neighbors = torch.zeros(
             (states_num * self.definition.n_generators, states.shape[1]),
@@ -203,10 +202,15 @@ class CayleyGraph:
 
     def get_neighbors_decoded(self, states: torch.Tensor) -> torch.Tensor:
         """Calculates neighbors in decoded (external) representation."""
-        """External int ---> external out"""
         return self.decode_states(self.get_neighbors(self.encode_states(states)))
 
     def get_constrained_neighbors(self, states, constraint_map):
+        """
+        Calculates all neighbors of `states` in internal representation while filtering 
+        on constraint_map. Example usage:
+            graph.get_constrained_neighbors(states, { 2: lambda S: S[:,0] < S[:,1] })
+        This means that if first and second elements are ordered then generator 2 will not be applied
+        """
         states_num = states.shape[0]
         max_out = states_num * self.definition.n_generators
 
@@ -216,7 +220,7 @@ class CayleyGraph:
             device=self.device,
         )
 
-        if constraint_map:  # You don't even need it if no constraints provided
+        if constraint_map:  
             decoded_states = self.decode_states(states)
         filled_index = 0
 
@@ -240,8 +244,7 @@ class CayleyGraph:
         return neighbors[:filled_index]
 
     def get_constrained_neighbors_decoded(self, states: torch.Tensor, constraint_map) -> torch.Tensor:
-        """Calculates neighbors in decoded (external) representation."""
-        """External int ---> external out"""
+        """Calculates neighbors in decoded (external) representation while applying constraint map."""
         return self.decode_states(self.get_constrained_neighbors(self.encode_states(states), constraint_map))
 
     def bfs(


### PR DESCRIPTION
Adds method get_constrained_neighbors which accepts a constraint_map: from generator to a predicate on the state. 
The constraint_map can also be applied on the beam search.
To avoid decoding/encoding penalties if incoming map is empty, no decoding is done.

The purpose of this construction is to remove certain subsets from the further processing, for example:
graph(PermutationGroup.lrx(n)).get_constrained_neighbors(states, { 2: lambda S: S[:,0] < S[:,1] })
this doesn't go down the X path if first two positions are already sorted.  