### PR TITLE
(Pylint) No max for graphs_lib.py

### DIFF
--- a/cayleypy/graphs_lib.py
+++ b/cayleypy/graphs_lib.py
@@ -1,3 +1,7 @@
+# We shall probably split this file into multiple submodules.
+# For now the following line will prevent pylint from complaining.
+# pylint: disable=too-many-lines
+
 """Library of pre-defined graphs."""
 
 from itertools import permutations, combinations


### PR DESCRIPTION
Some contributors are already facing the state where  `graphs_lib.py` to be too long for pylint deafalt setting (1000 lines). We prabably want to split it into several submodules, but for now the override will do.