### PR TITLE
Add neural network trainer module for Cayley graphs

### DIFF
--- a/cayleypy/trainers/__init__.py
+++ b/cayleypy/trainers/__init__.py
@@ -1,0 +1,9 @@
+"""Neural network training module for CayleyPy.
+
+This module provides tools for training neural networks to predict distances
+in Cayley graphs using both supervised learning and reinforcement learning approaches.
+"""
+
+from .trainer import Trainer
+
+__all__ = ['Trainer']

--- a/cayleypy/trainers/trainer.py
+++ b/cayleypy/trainers/trainer.py
@@ -1,0 +1,280 @@
+"""Neural network trainer for Cayley graph distance prediction."""
+
+from typing import TYPE_CHECKING, Dict, Any, List, Optional, Union
+import torch
+from tqdm import tqdm
+
+if TYPE_CHECKING:
+    from ..cayley_graph import CayleyGraph
+
+
+class Trainer:
+    """Trainer for neural network models on Cayley graphs.
+
+    This class provides methods for training neural networks to predict distances
+    in Cayley graphs using both supervised learning with random walks and
+    reinforcement learning with k-step lookahead.
+    """
+
+    def __init__(
+        self, 
+        model: torch.nn.Module, 
+        graph: "CayleyGraph", 
+        optimizer: torch.optim.Optimizer, 
+        loss_fn: torch.nn.Module, 
+        CFG: Dict[str, Any]
+    ):
+        """Initialize the trainer.
+
+        :param model: The neural network model to train.
+        :param graph: The Cayley graph to train on.
+        :param optimizer: The optimizer for training.
+        :param loss_fn: The loss function to use.
+        :param CFG: Configuration dictionary containing training parameters.
+        """
+        self.model = model
+        self.graph = graph
+        self.optimizer = optimizer
+        self.loss_fn = loss_fn
+        self.device = graph.device
+        self.CFG = CFG
+        self.nn_success_rates: Dict[Any, Any] = {}
+
+    def train_supervised(
+        self, 
+        model: torch.nn.Module, 
+        graph: "CayleyGraph", 
+        optimizer: torch.optim.Optimizer, 
+        loss_fn: torch.nn.Module, 
+        device: torch.device, 
+        CFG: Dict[str, Any]
+    ) -> None:
+        """Train the model using supervised learning with random walks.
+
+        This method generates random walks on the Cayley graph and uses them as training data
+        to teach the model to predict distances from the start state. The training uses
+        non-backtracking random walks for better mixing properties.
+
+        :param model: The neural network model to train.
+        :param graph: The Cayley graph to generate walks on.
+        :param optimizer: The optimizer for parameter updates.
+        :param loss_fn: The loss function to minimize.
+        :param device: The device to run training on.
+        :param CFG: Configuration dictionary with training parameters.
+        """
+        pbar = tqdm(range(CFG["num_epochs_supervised"]), desc="Training MLP with random walks")
+        for epoch in pbar:
+            # Generate random walks using non-backtracking mode for better mixing
+            X_tr, y_tr = graph.random_walks(
+                width=CFG["random_walks_width"], 
+                length=CFG["random_walks_length"], 
+                mode="nbt", 
+                nbt_history_depth=6
+            )
+
+            # Convert targets to float and shuffle training data
+            y_train = y_tr.float()
+            indices = torch.randperm(X_tr.shape[0], dtype=torch.int64, device='cpu')
+            X_train = X_tr[indices]
+            y_train = y_train[indices]
+            
+            model.train()
+
+            # Training loop over batches
+            n_states_all = X_train.shape[0]
+            cc = 0
+            train_loss = 0.0
+            for i_start_batch in range(0, n_states_all, CFG['batch_size']):
+                i_end_batch = min(i_start_batch + CFG['batch_size'], n_states_all)
+                
+                # Forward pass
+                outputs = model(X_train[i_start_batch:i_end_batch])
+                loss = loss_fn(outputs.squeeze(), y_train[i_start_batch:i_end_batch])
+
+                # Backward pass
+                optimizer.zero_grad()
+                loss.backward()
+                optimizer.step()
+                train_loss += loss.item()
+                cc += 1
+            
+            train_loss /= cc
+
+            # Update progress bar with current loss
+            if (epoch + 1) % 10 == 0:
+                pbar.set_postfix(loss=f"{loss:.4f}")
+
+    def train_rl(
+        self, 
+        model: torch.nn.Module, 
+        graph: "CayleyGraph", 
+        optimizer: torch.optim.Optimizer, 
+        loss_fn: torch.nn.Module, 
+        device: torch.device, 
+        CFG: Dict[str, Any], 
+        k_steps: int = 2
+    ) -> None:
+        """Train the model using reinforcement learning with k-step lookahead.
+
+        This method uses a k-step lookahead approach where the model predicts distances
+        for states reached by applying generators k steps ahead. This helps the model
+        learn better distance estimates by considering multiple possible paths.
+
+        :param model: The neural network model to train.
+        :param graph: The Cayley graph to train on.
+        :param optimizer: The optimizer for parameter updates.
+        :param loss_fn: The loss function to minimize.
+        :param device: The device to run training on.
+        :param CFG: Configuration dictionary with training parameters.
+        :param k_steps: Number of steps to look ahead for RL training.
+        """
+        tensor_generators = torch.tensor(graph.generators, device=device)
+        pbar = tqdm(range(CFG["num_epochs_rl"]), desc=f"{k_steps}-step RL")
+        
+        for epoch in pbar:
+            # Generate random walks for training data
+            X_all, _ = graph.random_walks(
+                width=CFG["random_walks_width"], 
+                length=CFG["random_walks_length"], 
+                mode="nbt", 
+                nbt_history_depth=6
+            )
+            X_all = X_all.to(device)
+            n_states = X_all.size(0)
+            n_actions = tensor_generators.size(0)
+            state_size = X_all.size(1)
+            y_all = torch.full((n_states,), float('inf'), device=device)
+
+            model.eval()
+            with torch.no_grad():
+                # k-step lookahead: for each generator, apply it k times and get predictions
+                for action_idx in range(n_actions):
+                    gen = tensor_generators[action_idx]
+                    neighbors = torch.gather(X_all, 1, gen.expand(n_states, -1))
+                    preds = []
+                    
+                    # Process in batches to avoid memory issues
+                    for i in range(0, n_states, 256):
+                        batch = neighbors[i:i+256]
+                        rollout = batch
+                        path_preds = []
+                        
+                        # Apply generator k times and collect predictions
+                        for step in range(k_steps):
+                            pred = model(rollout).squeeze()
+                            path_preds.append(pred + step + 1)
+                            rollout = torch.gather(rollout, 1, gen.expand(batch.size(0), -1))
+                        
+                        # Take minimum prediction across k steps
+                        best_pred = torch.min(torch.stack(path_preds, dim=0), dim=0).values
+                        preds.append(best_pred)
+                    
+                    pred = torch.cat(preds, dim=0)
+                    y_all = torch.min(y_all, pred)
+                
+            # Set goal state distance to 0 and ensure minimum distance of 1
+            goal_state = torch.arange(state_size, device=device)
+            is_goal = (X_all == goal_state).all(dim=1)
+            y_all = torch.clamp_min(y_all, 1)
+            y_all[is_goal] = 0
+            y_all = y_all.float()
+
+            # Split data into train/validation sets
+            n_samples = X_all.size(0)
+            n_val = int(n_samples * 0.1)
+            n_train = n_samples - n_val
+            perm = torch.randperm(n_samples, device=device)
+            train_idx = perm[:n_train]
+            val_idx = perm[n_train:]
+
+            # Training loop
+            model.train()
+            total_train_loss = 0.0
+            for start in range(0, n_train, CFG["batch_size"]):
+                end = start + CFG["batch_size"]
+                batch_idx = train_idx[start:end]
+                xb = X_all[batch_idx]
+                yb = y_all[batch_idx]
+                
+                optimizer.zero_grad()
+                pred = model(xb).squeeze()
+                loss = loss_fn(pred, yb)
+                loss.backward()
+                optimizer.step()
+                total_train_loss += loss.item() * xb.size(0)
+
+            # Validation
+            model.eval()
+            with torch.no_grad():
+                val_pred = model(X_all[val_idx]).squeeze()
+                val_loss = loss_fn(val_pred, y_all[val_idx]).item()
+            
+            # Update progress bar
+            if (epoch + 1) % 10 == 0:
+                anchor_loss = total_train_loss / n_train
+                hinge_loss = val_loss
+                total_loss = anchor_loss + hinge_loss
+                pbar.set_postfix(anchor=f"{anchor_loss:.4f}", hinge=f"{hinge_loss:.4f}", loss=f"{total_loss:.4f}")
+
+    def evaluate(
+        self, 
+        model: torch.nn.Module, 
+        graph: "CayleyGraph", 
+        validation_states: List[Any], 
+        CFG: Dict[str, Any]
+    ) -> None:
+        """Evaluate the model using beam search on validation states.
+
+        This method runs beam search with the trained model as a predictor to evaluate
+        how well the model can guide the search to find optimal paths.
+
+        :param model: The trained neural network model to use as predictor.
+        :param graph: The Cayley graph to perform beam search on.
+        :param validation_states: List of states to evaluate the model on.
+        :param CFG: Configuration dictionary with evaluation parameters.
+        """
+        print("Starting beam search evaluation...")
+        for start_state in validation_states:
+            self.nn_success_rates[start_state] = graph.beam_search(
+                start_state=start_state,
+                beam_width=1,
+                beam_mode=CFG["beam_mode"],
+                max_steps=CFG["max_steps"],
+                predictor=model,
+                history_depth=CFG["history_depth"],
+                verbose=1
+            )
+
+    def train(self, validation_states: List[Any]) -> None:
+        """Run the complete training and evaluation pipeline.
+
+        This method orchestrates the full training process including:
+        1. Supervised training with random walks
+        2. Initial evaluation with beam search
+        3. Optional reinforcement learning fine-tuning
+        4. Final evaluation
+
+        :param validation_states: List of states to evaluate the model on.
+        """
+        print("\n=== Starting model training and evaluation process ===\n")
+
+        print("\n3. Setting up loss function and optimizer...")
+        loss_fn = torch.nn.MSELoss()
+        optimizer = torch.optim.AdamW(
+            self.model.parameters(), 
+            lr=self.CFG["learning_rate"], 
+            weight_decay=1e-5
+        )
+
+        print("\n4. Starting supervised training with random walks...")
+        self.train_supervised(self.model, self.graph, optimizer, loss_fn, self.device, self.CFG)
+
+        print("\n5. Running initial beam search evaluation...")
+        self.evaluate(self.model, self.graph, validation_states, self.CFG)
+
+        if self.CFG['num_epochs_rl'] > 0:
+            print("\n6. Starting reinforcement learning fine-tuning...")
+            self.train_rl(self.model, self.graph, optimizer, loss_fn, self.device, self.CFG)
+
+            print("\n7. Running final beam search evaluation...")
+            self.evaluate(self.model, self.graph, validation_states, self.CFG)

--- a/cayleypy/trainers/trainer_test.py
+++ b/cayleypy/trainers/trainer_test.py
@@ -1,0 +1,271 @@
+"""Tests for the Trainer class."""
+
+import pytest
+import torch
+import torch.nn as nn
+from unittest.mock import Mock, patch
+
+from .trainer import Trainer
+from ..cayley_graph import CayleyGraph
+from ..graphs_lib import PermutationGroups
+
+
+class TestTrainer:
+    """Test cases for the Trainer class."""
+
+    @pytest.fixture
+    def mock_graph(self):
+        """Create a mock Cayley graph for testing."""
+        graph_def = PermutationGroups.lrx(4)
+        graph = Mock(spec=CayleyGraph)
+        graph.device = torch.device('cpu')
+        graph.generators = [[1, 0, 2, 3], [0, 2, 1, 3], [0, 1, 3, 2]]
+        graph.beam_search = Mock(return_value={'success': True, 'path_length': 5})
+        return graph
+
+    @pytest.fixture
+    def simple_model(self):
+        """Create a simple neural network model for testing."""
+        return nn.Linear(4, 1)
+
+    @pytest.fixture
+    def config(self):
+        """Create a configuration dictionary for testing."""
+        return {
+            'num_epochs_supervised': 2,
+            'num_epochs_rl': 1,
+            'random_walks_width': 100,
+            'random_walks_length': 10,
+            'batch_size': 32,
+            'learning_rate': 0.001,
+            'beam_mode': 'greedy',
+            'max_steps': 20,
+            'history_depth': 3
+        }
+
+    @pytest.fixture
+    def trainer(self, simple_model, mock_graph, config):
+        """Create a Trainer instance for testing."""
+        optimizer = torch.optim.Adam(simple_model.parameters(), lr=config['learning_rate'])
+        loss_fn = nn.MSELoss()
+        return Trainer(simple_model, mock_graph, optimizer, loss_fn, config)
+
+    def test_trainer_initialization(self, trainer, simple_model, mock_graph, config):
+        """Test that Trainer initializes correctly."""
+        assert trainer.model == simple_model
+        assert trainer.graph == mock_graph
+        assert trainer.CFG == config
+        assert trainer.device == mock_graph.device
+        assert isinstance(trainer.nn_success_rates, dict)
+
+    def test_trainer_initialization_with_custom_optimizer(self, simple_model, mock_graph, config):
+        """Test Trainer initialization with custom optimizer."""
+        optimizer = torch.optim.SGD(simple_model.parameters(), lr=0.01)
+        loss_fn = nn.L1Loss()
+        trainer = Trainer(simple_model, mock_graph, optimizer, loss_fn, config)
+        
+        assert trainer.model == simple_model
+        assert trainer.optimizer == optimizer
+        assert trainer.loss_fn == loss_fn
+
+    @patch('cayleypy.trainers.trainer.tqdm')
+    def test_train_supervised(self, mock_tqdm, trainer, mock_graph):
+        """Test supervised training method."""
+        # Mock random_walks to return dummy data
+        mock_graph.random_walks.return_value = (
+            torch.randn(100, 4),  # X_tr
+            torch.randint(0, 10, (100,))  # y_tr
+        )
+        
+        # Mock tqdm progress bar to be iterable
+        mock_pbar = Mock()
+        mock_pbar.__iter__ = Mock(return_value=iter(range(trainer.CFG['num_epochs_supervised'])))
+        mock_tqdm.return_value = mock_pbar
+        
+        # Call train_supervised
+        trainer.train_supervised(
+            trainer.model, 
+            mock_graph, 
+            trainer.optimizer, 
+            trainer.loss_fn, 
+            trainer.device, 
+            trainer.CFG
+        )
+        
+        # Verify random_walks was called with correct parameters
+        expected_calls = trainer.CFG['num_epochs_supervised']
+        assert mock_graph.random_walks.call_count == expected_calls
+        
+        # Check that all calls had the correct parameters
+        for call in mock_graph.random_walks.call_args_list:
+            assert call.kwargs['width'] == trainer.CFG['random_walks_width']
+            assert call.kwargs['length'] == trainer.CFG['random_walks_length']
+            assert call.kwargs['mode'] == 'nbt'
+            assert call.kwargs['nbt_history_depth'] == 6
+        
+        # Verify tqdm was called
+        mock_tqdm.assert_called_once()
+        # set_postfix is only called every 10 epochs, so with 2 epochs it won't be called
+        # mock_pbar.set_postfix.assert_called()
+
+    @patch('cayleypy.trainers.trainer.tqdm')
+    def test_train_rl(self, mock_tqdm, trainer, mock_graph):
+        """Test reinforcement learning training method."""
+        # Mock random_walks to return dummy data
+        mock_graph.random_walks.return_value = (
+            torch.randn(100, 4),  # X_all
+            torch.randint(0, 10, (100,))  # y_all (not used in RL)
+        )
+        
+        # Mock tqdm progress bar to be iterable
+        mock_pbar = Mock()
+        mock_pbar.__iter__ = Mock(return_value=iter(range(trainer.CFG['num_epochs_rl'])))
+        mock_tqdm.return_value = mock_pbar
+        
+        # Call train_rl
+        trainer.train_rl(
+            trainer.model,
+            mock_graph,
+            trainer.optimizer,
+            trainer.loss_fn,
+            trainer.device,
+            trainer.CFG,
+            k_steps=2
+        )
+        
+        # Verify random_walks was called
+        mock_graph.random_walks.assert_called_once_with(
+            width=trainer.CFG['random_walks_width'],
+            length=trainer.CFG['random_walks_length'],
+            mode='nbt',
+            nbt_history_depth=6
+        )
+        
+        # Verify tqdm was called with correct description
+        mock_tqdm.assert_called_once()
+        call_args = mock_tqdm.call_args
+        assert "2-step RL" in str(call_args)
+
+    def test_evaluate(self, trainer, mock_graph):
+        """Test evaluation method."""
+        validation_states = [torch.tensor([0, 1, 2, 3]), torch.tensor([1, 0, 2, 3])]
+        
+        trainer.evaluate(trainer.model, mock_graph, validation_states, trainer.CFG)
+        
+        # Verify beam_search was called for each validation state
+        assert mock_graph.beam_search.call_count == len(validation_states)
+        
+        # Check that success rates were stored
+        assert len(trainer.nn_success_rates) == len(validation_states)
+
+    @patch.object(Trainer, 'train_supervised')
+    @patch.object(Trainer, 'evaluate')
+    @patch.object(Trainer, 'train_rl')
+    def test_train_pipeline(self, mock_train_rl, mock_evaluate, mock_train_supervised, trainer):
+        """Test the complete training pipeline."""
+        validation_states = [torch.tensor([0, 1, 2, 3])]
+        
+        # Test with RL enabled
+        trainer.CFG['num_epochs_rl'] = 1
+        trainer.train(validation_states)
+        
+        # Verify all methods were called
+        mock_train_supervised.assert_called_once()
+        assert mock_evaluate.call_count == 2  # Called twice (before and after RL)
+        mock_train_rl.assert_called_once()
+
+    @patch.object(Trainer, 'train_supervised')
+    @patch.object(Trainer, 'evaluate')
+    @patch.object(Trainer, 'train_rl')
+    def test_train_pipeline_no_rl(self, mock_train_rl, mock_evaluate, mock_train_supervised, trainer):
+        """Test the training pipeline with RL disabled."""
+        validation_states = [torch.tensor([0, 1, 2, 3])]
+        
+        # Test with RL disabled
+        trainer.CFG['num_epochs_rl'] = 0
+        trainer.train(validation_states)
+        
+        # Verify supervised training and evaluation were called
+        mock_train_supervised.assert_called_once()
+        mock_evaluate.assert_called_once()
+        
+        # Verify RL was not called
+        mock_train_rl.assert_not_called()
+
+    def test_trainer_with_different_loss_functions(self, simple_model, mock_graph, config):
+        """Test Trainer with different loss functions."""
+        # Test with L1Loss
+        l1_loss = nn.L1Loss()
+        optimizer = torch.optim.Adam(simple_model.parameters())
+        trainer_l1 = Trainer(simple_model, mock_graph, optimizer, l1_loss, config)
+        assert trainer_l1.loss_fn == l1_loss
+        
+        # Test with SmoothL1Loss
+        smooth_l1_loss = nn.SmoothL1Loss()
+        trainer_smooth = Trainer(simple_model, mock_graph, optimizer, smooth_l1_loss, config)
+        assert trainer_smooth.loss_fn == smooth_l1_loss
+
+    def test_trainer_with_different_optimizers(self, simple_model, mock_graph, config):
+        """Test Trainer with different optimizers."""
+        # Test with SGD
+        sgd_optimizer = torch.optim.SGD(simple_model.parameters(), lr=0.01)
+        loss_fn = nn.MSELoss()
+        trainer_sgd = Trainer(simple_model, mock_graph, sgd_optimizer, loss_fn, config)
+        assert trainer_sgd.optimizer == sgd_optimizer
+        
+        # Test with AdamW
+        adamw_optimizer = torch.optim.AdamW(simple_model.parameters(), lr=0.001)
+        trainer_adamw = Trainer(simple_model, mock_graph, adamw_optimizer, loss_fn, config)
+        assert trainer_adamw.optimizer == adamw_optimizer
+
+    def test_trainer_config_validation(self, simple_model, mock_graph):
+        """Test that Trainer handles configuration properly."""
+        config = {
+            'num_epochs_supervised': 5,
+            'num_epochs_rl': 3,
+            'random_walks_width': 200,
+            'random_walks_length': 15,
+            'batch_size': 64,
+            'learning_rate': 0.0001,
+            'beam_mode': 'beam',
+            'max_steps': 30,
+            'history_depth': 5
+        }
+        
+        optimizer = torch.optim.Adam(simple_model.parameters())
+        loss_fn = nn.MSELoss()
+        trainer = Trainer(simple_model, mock_graph, optimizer, loss_fn, config)
+        
+        assert trainer.CFG == config
+        assert trainer.CFG['num_epochs_supervised'] == 5
+        assert trainer.CFG['num_epochs_rl'] == 3
+        assert trainer.CFG['batch_size'] == 64
+
+    def test_trainer_device_handling(self, simple_model, mock_graph, config):
+        """Test that Trainer properly handles device assignment."""
+        # Test with CPU device
+        mock_graph.device = torch.device('cpu')
+        optimizer = torch.optim.Adam(simple_model.parameters())
+        loss_fn = nn.MSELoss()
+        trainer = Trainer(simple_model, mock_graph, optimizer, loss_fn, config)
+        
+        assert trainer.device == torch.device('cpu')
+        
+        # Test with CUDA device (if available)
+        if torch.cuda.is_available():
+            mock_graph.device = torch.device('cuda')
+            trainer_cuda = Trainer(simple_model, mock_graph, optimizer, loss_fn, config)
+            assert trainer_cuda.device == torch.device('cuda')
+
+    def test_trainer_success_rates_tracking(self, trainer):
+        """Test that Trainer properly tracks success rates."""
+        # Initially empty
+        assert len(trainer.nn_success_rates) == 0
+        
+        # Add some success rates
+        trainer.nn_success_rates['state1'] = {'success': True, 'path_length': 5}
+        trainer.nn_success_rates['state2'] = {'success': False, 'path_length': None}
+        
+        assert len(trainer.nn_success_rates) == 2
+        assert trainer.nn_success_rates['state1']['success'] is True
+        assert trainer.nn_success_rates['state2']['success'] is False

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -45,6 +45,15 @@ Beam search and ML
     cayleypy.algo.RandomWalksGenerator
     cayleypy.models.ModelConfig
 
+Neural network training
+'''''''''''''''''''''''
+
+
+.. autosummary::
+    :toctree: generated/
+
+    cayleypy.trainers.Trainer
+
 Special algorithms
 ''''''''''''''''''
 


### PR DESCRIPTION
## Add neural network trainer module

This PR adds a comprehensive `Trainer` class for training neural networks on Cayley graphs.

### Changes:
- **New module**: `cayleypy/trainers/` with `Trainer` class
- **Training methods**: Supervised learning with random walks and reinforcement learning with k-step lookahead
- **Comprehensive tests**: 12 test cases covering all functionality
- **Documentation**: Updated API docs with new "Neural network training" section

### Features:
- Supervised training using non-backtracking random walks
- Reinforcement learning with k-step lookahead
- Beam search evaluation
- Support for different optimizers and loss functions
- Full training pipeline with validation

All tests pass and code follows repository conventions.