### PR TITLE
Attempt to cache python environment in lint ci step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,10 +29,24 @@ jobs:
         with:
           python-version: '3.12'
           architecture: 'x64'
-      - name: Install requirements
-        run: pip install .[lint,test]
+      - name: Cache virtual environment
+        id: cache-venv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: ${{ runner.os }}-pip-${{ steps.setup-python.outputs.python-version }}-lint-test-${{ hashFiles('pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ steps.setup-python.outputs.python-version }}-lint-test-
+      - name: Create virtual environment
+        if: steps.cache-venv.outputs.cache-hit != 'true'
+        run: |
+          python -m venv .venv
+          source .venv/bin/activate
+          pip install .[lint,test]
       - name: Lint
-        run: ./lint.sh
+        run: |
+          source .venv/bin/activate
+          ./lint.sh
   pytest-ubuntu:
     strategy:
       matrix:


### PR DESCRIPTION
### Summary
I've tried to add caching for the Python environment in the `lint` CI job. This reduced the `lint` job duration from ~3 to ~1.5 minutes.

### Comments
At first, I tried caching the pip cache directory, but it takes longer to download the cache and install packages from it (possibly due to artifact build and check steps, ~2.5 minutes) than to install the requirements directly (~2 minutes in `Install requirements` step).

#### Before
<img width="631" height="475" alt="cayleypy_ci_before" src="https://github.com/user-attachments/assets/c0065222-897f-4657-85b6-14627e34b6ca" />

#### With pip cache
<img width="620" height="482" alt="caylepy_ci_using_pip_cache_warmed" src="https://github.com/user-attachments/assets/10e85c98-9260-4376-8a58-ad7bd458a528" />

#### Pip cache size
<img width="1311" height="184" alt="cayleypy_ci_cache_pip" src="https://github.com/user-attachments/assets/e7ca6825-86a6-4ce0-b138-b146192a957b" />

After that, I tried using a virtual environment, assuming that all built dependencies and packages would be in it and no external dependencies would be required.

#### With venv warm-up
<img width="614" height="537" alt="caylepy_ci_using_cache_warming_venv" src="https://github.com/user-attachments/assets/0d873866-41ee-40a4-8484-f374a09c1c72" />

#### With warmed venv cache
<img width="617" height="549" alt="caylepy_ci_using_cache_warmed_venv" src="https://github.com/user-attachments/assets/85d4f12f-2e42-4256-b0b8-085971500ccc" />

#### venv cache size
<img width="1296" height="161" alt="cayleypy_ci_cache_venv" src="https://github.com/user-attachments/assets/10ba2501-82cc-40d5-a2da-52b041a90ead" />

#### Cache key and dependencies:
The venv cache key is calculated based on `pyproject.toml`, so as long as we don't change it, a cache hit will occur. I can change it to use only the list of dependencies in `pyproject.toml` if needed.

### Further plans
I've tried adding venv caching to test jobs, but each Python version (according to the matrix) stores ~4 GiB in cache, and I quickly reached my GitHub cache limit. If we can store large cache artifacts in the project, I can implement it later.
