### PR TITLE
Add score_children contract, ModelConfig v2 and self-describing checkpoints

### DIFF
--- a/cayleypy/__init__.py
+++ b/cayleypy/__init__.py
@@ -5,5 +5,6 @@ from .cayley_path import CayleyPath
 from .create_graph import create_graph
 from .datasets import load_dataset
 from .graphs_lib import prepare_graph, PermutationGroups, MatrixGroups
+from .models import ModelConfig, load_checkpoint, save_checkpoint
 from .predictor import Predictor
 from .puzzles import Puzzles, GapPuzzles

--- a/cayleypy/models/__init__.py
+++ b/cayleypy/models/__init__.py
@@ -1,1 +1,2 @@
+from .checkpoint import graph_hash, load_checkpoint, save_checkpoint
 from .models import ModelConfig

--- a/cayleypy/models/checkpoint.py
+++ b/cayleypy/models/checkpoint.py
@@ -1,0 +1,116 @@
+"""Self-describing checkpoints for models used as predictors."""
+
+import hashlib
+import json
+import os
+import typing
+from dataclasses import replace
+from typing import Any, Optional, Union
+
+import torch
+from torch import nn
+
+from .models import ModelConfig
+
+if typing.TYPE_CHECKING:
+    from ..cayley_graph_def import CayleyGraphDef
+
+# Version of the checkpoint format. It is incremented when the format changes in a non-backward-compatible way.
+CHECKPOINT_FORMAT_VERSION = 1
+
+PathType = Union[str, os.PathLike]
+
+
+def graph_hash(graph_def: "CayleyGraphDef") -> str:
+    """Computes hash of the mathematical definition of a graph.
+
+    Only data affecting mathematical properties of the graph is hashed: type of generators, the generators themselves,
+    and the central state. Names of the graph and of its generators are deliberately not hashed, so renaming a graph
+    does not invalidate checkpoints of models trained for it.
+
+    :param graph_def: Definition of the graph.
+    :return: Hexadecimal sha256 hash of the definition.
+    """
+    generators: Any
+    if graph_def.is_permutation_group():
+        generators = [[int(x) for x in perm] for perm in graph_def.generators_permutations]
+    else:
+        generators = [[g.matrix.tolist(), int(g.modulo)] for g in graph_def.generators_matrices]
+    data = {
+        "generators_type": graph_def.generators_type.name,
+        "generators": generators,
+        "central_state": [int(x) for x in graph_def.central_state],
+    }
+    return hashlib.sha256(json.dumps(data, sort_keys=True).encode("utf-8")).hexdigest()
+
+
+def save_checkpoint(
+    path: PathType,
+    model: nn.Module,
+    config: ModelConfig,
+    graph_def: Optional["CayleyGraphDef"] = None,
+) -> ModelConfig:
+    """Saves weights of a model together with the config describing this model.
+
+    Unlike a bare state dict, such checkpoint is self-describing: :func:`load_checkpoint` recreates the model from it
+    without knowing the architecture in advance.
+
+    :param path: Path to the file to write.
+    :param model: Model whose weights to save.
+    :param config: Config describing `model`.
+    :param graph_def: Definition of the graph this model was trained for (optional). If given, hash of this definition
+        is stored in the checkpoint, and :func:`load_checkpoint` will check it.
+    :return: Config stored in the checkpoint (it differs from `config` when `graph_def` is given).
+    """
+    if graph_def is not None:
+        config = replace(config, graph_hash=graph_hash(graph_def))
+    checkpoint = {
+        "format_version": CHECKPOINT_FORMAT_VERSION,
+        "config": config.to_dict(),
+        "state_dict": model.state_dict(),
+    }
+    torch.save(checkpoint, path)
+    return config
+
+
+def load_checkpoint(
+    path: PathType,
+    device: str = "cpu",
+    graph_def: Optional["CayleyGraphDef"] = None,
+) -> tuple[nn.Module, ModelConfig]:
+    """Loads model from a checkpoint written by :func:`save_checkpoint`.
+
+    The returned model is in evaluation mode.
+
+    :param path: Path to the checkpoint file.
+    :param device: PyTorch device to load the model to.
+    :param graph_def: Definition of the graph this model is going to be used with (optional). If given, and the
+        checkpoint contains hash of the graph it was trained for, these graphs must be the same.
+    :return: Pair (model, config describing this model).
+    """
+    # `weights_only=True` is passed explicitly: checkpoints contain only tensors and primitive values, so we never need
+    # to unpickle arbitrary objects from them (and must not, because checkpoints can be downloaded from the internet).
+    checkpoint = torch.load(path, map_location=device, weights_only=True)
+    if not isinstance(checkpoint, dict) or "config" not in checkpoint or "state_dict" not in checkpoint:
+        raise ValueError(
+            f"File {path} is not a CayleyPy checkpoint (expected dict with keys 'config' and 'state_dict'). "
+            "Bare state dicts must be loaded with ModelConfig.load."
+        )
+    format_version = int(checkpoint.get("format_version", 0))
+    if format_version > CHECKPOINT_FORMAT_VERSION:
+        raise ValueError(
+            f"Checkpoint {path} has format version {format_version}, but this version of CayleyPy supports only "
+            f"versions up to {CHECKPOINT_FORMAT_VERSION}. Please update CayleyPy."
+        )
+    config = ModelConfig.from_dict(checkpoint["config"])
+    if graph_def is not None and config.graph_hash is not None:
+        expected_hash = graph_hash(graph_def)
+        if config.graph_hash != expected_hash:
+            raise ValueError(
+                f"Checkpoint {path} was trained for another graph (hash in checkpoint is {config.graph_hash}, "
+                f"hash of the given graph is {expected_hash})."
+            )
+    model = config.build_model()
+    model.load_state_dict(checkpoint["state_dict"])
+    model.eval()
+    return model.to(device), config

--- a/cayleypy/models/checkpoint_test.py
+++ b/cayleypy/models/checkpoint_test.py
@@ -1,0 +1,109 @@
+import pytest
+import torch
+
+from .checkpoint import CHECKPOINT_FORMAT_VERSION, graph_hash, load_checkpoint, save_checkpoint
+from .models import ModelConfig
+from ..graphs_lib import MatrixGroups, PermutationGroups
+
+MLP_CONFIG = ModelConfig(model_type="MLP", input_size=5, num_classes_for_one_hot=5, layers_sizes=[8, 8])
+STATES = torch.tensor([[0, 1, 2, 3, 4], [4, 3, 2, 1, 0], [1, 0, 2, 4, 3]])
+
+
+def test_save_and_load(tmp_path):
+    path = tmp_path / "model.pt"
+    model = MLP_CONFIG.build_model()
+    save_checkpoint(path, model, MLP_CONFIG)
+
+    loaded_model, loaded_config = load_checkpoint(path)
+    assert loaded_config == MLP_CONFIG
+    assert not loaded_model.training  # Loaded model is in evaluation mode.
+    with torch.no_grad():
+        assert torch.equal(loaded_model(STATES), model(STATES))
+
+
+def test_save_and_load_with_graph(tmp_path):
+    path = tmp_path / "model.pt"
+    graph_def = PermutationGroups.lrx(5)
+    model = MLP_CONFIG.build_model()
+
+    stored_config = save_checkpoint(path, model, MLP_CONFIG, graph_def)
+    assert stored_config.graph_hash == graph_hash(graph_def)
+
+    loaded_model, loaded_config = load_checkpoint(path, graph_def=graph_def)
+    assert loaded_config.graph_hash == graph_hash(graph_def)
+    with torch.no_grad():
+        assert torch.equal(loaded_model(STATES), model(STATES))
+
+
+def test_load_checkpoint_for_another_graph(tmp_path):
+    path = tmp_path / "model.pt"
+    save_checkpoint(path, MLP_CONFIG.build_model(), MLP_CONFIG, PermutationGroups.lrx(5))
+    with pytest.raises(ValueError, match="was trained for another graph"):
+        load_checkpoint(path, graph_def=PermutationGroups.lrx(6))
+
+
+def test_load_checkpoint_without_graph_hash(tmp_path):
+    path = tmp_path / "model.pt"
+    save_checkpoint(path, MLP_CONFIG.build_model(), MLP_CONFIG)
+
+    # Checkpoint has no graph hash, so there is nothing to check against the given graph.
+    _, loaded_config = load_checkpoint(path, graph_def=PermutationGroups.lrx(5))
+    assert loaded_config.graph_hash is None
+
+
+def test_load_bare_state_dict(tmp_path):
+    path = tmp_path / "model.pt"
+    torch.save(MLP_CONFIG.build_model().state_dict(), path)
+    with pytest.raises(ValueError, match="not a CayleyPy checkpoint"):
+        load_checkpoint(path)
+
+
+def test_load_checkpoint_of_unsupported_version(tmp_path):
+    path = tmp_path / "model.pt"
+    model = MLP_CONFIG.build_model()
+    checkpoint = {
+        "format_version": CHECKPOINT_FORMAT_VERSION + 1,
+        "config": MLP_CONFIG.to_dict(),
+        "state_dict": model.state_dict(),
+    }
+    torch.save(checkpoint, path)
+    with pytest.raises(ValueError, match="format version"):
+        load_checkpoint(path)
+
+
+def test_graph_hash_is_deterministic():
+    assert graph_hash(PermutationGroups.lrx(5)) == graph_hash(PermutationGroups.lrx(5))
+    assert len(graph_hash(PermutationGroups.lrx(5))) == 64
+
+
+def test_graph_hash_depends_on_math_only():
+    graph_def = PermutationGroups.lrx(5)
+
+    # Names of the graph and of its generators do not affect mathematical properties of the graph.
+    assert graph_hash(graph_def.with_name("other name")) == graph_hash(graph_def)
+
+    # Generators and central state do.
+    assert graph_hash(PermutationGroups.lrx(6)) != graph_hash(graph_def)
+    assert graph_hash(PermutationGroups.cyclic_coxeter(5)) != graph_hash(graph_def)
+    assert graph_hash(graph_def.with_central_state([0, 0, 1, 1, 2])) != graph_hash(graph_def)
+
+
+def test_graph_hash_for_matrix_group():
+    graph_def = MatrixGroups.heisenberg()
+    assert graph_hash(graph_def) == graph_hash(MatrixGroups.heisenberg())
+    assert len(graph_hash(graph_def)) == 64
+    assert graph_hash(MatrixGroups.heisenberg(modulo=5)) != graph_hash(graph_def)
+    assert graph_hash(MatrixGroups.heisenberg(n=4)) != graph_hash(graph_def)
+
+
+def test_save_and_load_for_matrix_group(tmp_path):
+    path = tmp_path / "model.pt"
+    graph_def = MatrixGroups.heisenberg()
+    config = ModelConfig(model_type="MLP", input_size=graph_def.state_size, num_classes_for_one_hot=2, layers_sizes=[8])
+    stored_config = save_checkpoint(path, config.build_model(), config, graph_def)
+    assert stored_config.graph_hash == graph_hash(graph_def)
+
+    _, loaded_config = load_checkpoint(path, graph_def=graph_def)
+    assert loaded_config == stored_config
+    with pytest.raises(ValueError, match="was trained for another graph"):
+        load_checkpoint(path, graph_def=MatrixGroups.heisenberg(modulo=5))

--- a/cayleypy/models/models.py
+++ b/cayleypy/models/models.py
@@ -1,7 +1,7 @@
 # pylint: disable=not-callable
 
 import os
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from typing import Any, Optional
 
 import kagglehub
@@ -11,7 +11,25 @@ from torch import nn
 
 @dataclass(frozen=True)
 class ModelConfig:
-    """Configuration used to describe ML model."""
+    """Configuration used to describe ML model.
+
+    Fields `n_outputs`, `tokenizer_groups` and `graph_hash` describe capabilities added after the first version of this
+    class. Their defaults describe a single-output model without tokenization, which is not tied to a particular graph,
+    so configs written before these fields existed keep working.
+
+    :param model_type: Type of the model, e.g. "MLP".
+    :param input_size: Number of elements in one state.
+    :param num_classes_for_one_hot: Number of distinct values one element of a state can take.
+    :param layers_sizes: Sizes of hidden layers.
+    :param weights_kaggle_id: Id of the Kaggle model with weights (optional).
+    :param weights_path: Path to the file with weights (optional).
+    :param n_outputs: Number of outputs of the model. 1 means the model predicts distance for the state it is applied
+        to. `n_generators` means the model predicts distance for every child of that state (Q-model).
+    :param tokenizer_groups: Specification of how elements of a state are grouped into tokens, as a list of
+        ``[group_size, num_groups]`` pairs. For example, ``[[3, 20], [2, 30]]`` means 20 tokens of 3 elements followed
+        by 30 tokens of 2 elements. None means the state is not tokenized.
+    :param graph_hash: Hash of the graph this model was trained for, see :func:`cayleypy.models.graph_hash`.
+    """
 
     model_type: str
     input_size: int
@@ -19,6 +37,9 @@ class ModelConfig:
     layers_sizes: list[int]
     weights_kaggle_id: Optional[str] = None
     weights_path: Optional[str] = None
+    n_outputs: int = 1
+    tokenizer_groups: Optional[list[list[int]]] = None
+    graph_hash: Optional[str] = None
 
     @staticmethod
     def from_dict(cfg: dict[str, Any]):
@@ -30,9 +51,17 @@ class ModelConfig:
             layers_sizes=cfg["layers_sizes"],
             weights_kaggle_id=cfg.get("weights_kaggle_id", None),
             weights_path=cfg.get("weights_path", None),
+            n_outputs=cfg.get("n_outputs", 1),
+            tokenizer_groups=cfg.get("tokenizer_groups", None),
+            graph_hash=cfg.get("graph_hash", None),
         )
 
-    def _build_model(self) -> nn.Module:
+    def to_dict(self) -> dict[str, Any]:
+        """Converts this config to a Python dict containing only primitive values."""
+        return asdict(self)
+
+    def build_model(self) -> nn.Module:
+        """Creates model described by this config, with randomly initialized weights."""
         if self.model_type == "MLP":
             return MlpModel(self)
         else:
@@ -40,13 +69,14 @@ class ModelConfig:
 
     def load(self, device="cpu") -> nn.Module:
         """Creates model described by this config and loads weights."""
-        model = self._build_model()
+        model = self.build_model()
         if self.weights_path is not None:
             path = self.weights_path
             if self.weights_kaggle_id is not None:
                 model_dir = kagglehub.model_download(self.weights_kaggle_id)
                 path = os.path.join(model_dir, path)
-            model.load_state_dict(torch.load(path, map_location=device))
+            # Weights in this format are bare state dicts, so we never need to unpickle arbitrary objects from them.
+            model.load_state_dict(torch.load(path, map_location=device, weights_only=True))
         return model.to(device)
 
 
@@ -56,6 +86,8 @@ class MlpModel(nn.Module):
     def __init__(self, config):
         super().__init__()
         assert config.model_type == "MLP"
+        if config.n_outputs != 1:
+            raise ValueError(f"MlpModel supports only n_outputs=1, got {config.n_outputs}.")
         self.num_classes_for_one_hot = config.num_classes_for_one_hot
         self.input_layer_size = config.input_size * self.num_classes_for_one_hot
 

--- a/cayleypy/models/models.py
+++ b/cayleypy/models/models.py
@@ -68,7 +68,21 @@ class ModelConfig:
             raise ValueError("Unknown model type: " + self.model_type)
 
     def load(self, device="cpu") -> nn.Module:
-        """Creates model described by this config and loads weights."""
+        """Creates model described by this config and loads weights.
+
+        Weights are loaded from `weights_path`. A config with neither `weights_path` nor `weights_kaggle_id` describes
+        an untrained model, and the returned model has randomly initialized weights.
+
+        :param device: PyTorch device to load the model to.
+        :return: The model.
+        """
+        if self.weights_path is None and self.weights_kaggle_id is not None:
+            # A Kaggle model is a directory, so without weights_path there is no way to tell which file in it holds the
+            # weights - and silently returning a randomly initialized model instead is much worse than failing here.
+            raise ValueError(
+                f'Config has weights_kaggle_id="{self.weights_kaggle_id}" but no weights_path, so it is not known '
+                "which file of that Kaggle model holds the weights. Set weights_path to the name of that file."
+            )
         model = self.build_model()
         if self.weights_path is not None:
             path = self.weights_path

--- a/cayleypy/models/models_test.py
+++ b/cayleypy/models/models_test.py
@@ -1,0 +1,91 @@
+import json
+
+import pytest
+import torch
+
+from .models import MlpModel, ModelConfig
+
+# Config in the format that existed before n_outputs, tokenizer_groups and graph_hash were added.
+LEGACY_CONFIG_DICT = {
+    "model_type": "MLP",
+    "input_size": 16,
+    "num_classes_for_one_hot": 16,
+    "layers_sizes": [256, 256],
+    "weights_kaggle_id": "fedimser/lrx-16/pyTorch/ep60/1",
+    "weights_path": "model_ep60.pth",
+}
+
+
+def test_from_dict_legacy():
+    config = ModelConfig.from_dict(LEGACY_CONFIG_DICT)
+    assert config.model_type == "MLP"
+    assert config.input_size == 16
+    assert config.num_classes_for_one_hot == 16
+    assert config.layers_sizes == [256, 256]
+    assert config.weights_kaggle_id == "fedimser/lrx-16/pyTorch/ep60/1"
+    assert config.weights_path == "model_ep60.pth"
+
+    # Defaults describe single-output model without tokenization, not tied to any graph.
+    assert config.n_outputs == 1
+    assert config.tokenizer_groups is None
+    assert config.graph_hash is None
+
+
+def test_from_dict_new_fields():
+    config = ModelConfig.from_dict(
+        {
+            "model_type": "MLP",
+            "input_size": 120,
+            "num_classes_for_one_hot": 60,
+            "layers_sizes": [64],
+            "n_outputs": 12,
+            "tokenizer_groups": [[3, 20], [2, 30]],
+            "graph_hash": "abc123",
+        }
+    )
+    assert config.n_outputs == 12
+    assert config.tokenizer_groups == [[3, 20], [2, 30]]
+    assert config.graph_hash == "abc123"
+
+
+def test_to_dict_round_trip():
+    config = ModelConfig(
+        model_type="MLP",
+        input_size=120,
+        num_classes_for_one_hot=60,
+        layers_sizes=[64, 32],
+        n_outputs=12,
+        tokenizer_groups=[[3, 20], [2, 30]],
+        graph_hash="abc123",
+    )
+    as_dict = config.to_dict()
+
+    # Config must be convertible to a dict of primitives (so it can be stored in a checkpoint).
+    assert as_dict["layers_sizes"] == [64, 32]
+    assert as_dict["tokenizer_groups"] == [[3, 20], [2, 30]]
+    assert ModelConfig.from_dict(as_dict) == config
+
+
+def test_to_dict_is_json_serializable():
+    config = ModelConfig.from_dict(LEGACY_CONFIG_DICT)
+    assert json.loads(json.dumps(config.to_dict())) == config.to_dict()
+
+
+def test_build_mlp_model():
+    config = ModelConfig(model_type="MLP", input_size=5, num_classes_for_one_hot=5, layers_sizes=[8, 8])
+    model = config.build_model()
+    assert isinstance(model, MlpModel)
+    states = torch.tensor([[0, 1, 2, 3, 4], [4, 3, 2, 1, 0]])
+    assert model(states).shape == (2,)
+
+
+def test_build_model_unknown_type():
+    config = ModelConfig(model_type="NoSuchModel", input_size=5, num_classes_for_one_hot=5, layers_sizes=[8])
+    with pytest.raises(ValueError, match="Unknown model type"):
+        config.build_model()
+
+
+def test_build_mlp_model_with_multiple_outputs():
+    config = ModelConfig(model_type="MLP", input_size=5, num_classes_for_one_hot=5, layers_sizes=[8], n_outputs=3)
+    with pytest.raises(ValueError, match="n_outputs"):
+        config.build_model()

--- a/cayleypy/models/models_test.py
+++ b/cayleypy/models/models_test.py
@@ -89,3 +89,23 @@ def test_build_mlp_model_with_multiple_outputs():
     config = ModelConfig(model_type="MLP", input_size=5, num_classes_for_one_hot=5, layers_sizes=[8], n_outputs=3)
     with pytest.raises(ValueError, match="n_outputs"):
         config.build_model()
+
+
+def test_load_rejects_kaggle_id_without_weights_path():
+    """Test that a config naming a Kaggle model but no file in it fails instead of loading nothing."""
+    config = ModelConfig(
+        model_type="MLP",
+        input_size=5,
+        num_classes_for_one_hot=5,
+        layers_sizes=[8],
+        weights_kaggle_id="no/such/model/1",
+    )
+    with pytest.raises(ValueError, match="weights_path"):
+        config.load()
+
+
+def test_load_without_weights_returns_untrained_model():
+    """Test that a config with no weights at all is still loadable (it describes an untrained model)."""
+    config = ModelConfig(model_type="MLP", input_size=5, num_classes_for_one_hot=5, layers_sizes=[8])
+    model = config.load()
+    assert isinstance(model, MlpModel)

--- a/cayleypy/predictor.py
+++ b/cayleypy/predictor.py
@@ -55,11 +55,20 @@ class Predictor:
         model = PREDICTOR_MODELS[graph.definition.name].load(graph.device)
         return Predictor(graph, model)
 
+    def _predict_as_tensor(self, states: torch.Tensor) -> torch.Tensor:
+        """Applies the underlying model to `states` and returns its output as a tensor on the graph's device.
+
+        A model does not have to be written in torch - an sklearn estimator, for example, is a supported predictor and
+        its `predict` returns a NumPy array, which has only some of the operations the callers of this method use.
+        """
+        return torch.as_tensor(self.predict(states), device=self.graph.device)
+
     def predict_batched(self, states: torch.Tensor) -> torch.Tensor:
         """Applies the underlying model to `states`, splitting them into batches if there are too many.
 
-        Output of the model is returned as is. It has shape ``[n_states]`` for usual (single-output) models, and shape
-        ``[n_states, n_outputs]`` for multi-output models (e.g. models predicting one score per generator).
+        The shape of the output is the shape the model returns: ``[n_states]`` for usual (single-output) models, and
+        ``[n_states, n_outputs]`` for multi-output models (e.g. models predicting one score per generator). Output of a
+        model that does not return tensors is converted to one.
 
         :param states: States (in decoded representation) to apply the model to.
         :return: Output of the model for `states`.
@@ -71,11 +80,11 @@ class Predictor:
             if num_batches > 1:
                 ans = []  # type: list[torch.Tensor]
                 for batch in states.tensor_split(num_batches, dim=0):
-                    ans.append(self.predict(batch))
+                    ans.append(self._predict_as_tensor(batch))
                 # Batches must be concatenated along dimension 0, otherwise outputs of multi-output models are mangled.
                 return torch.cat(ans, dim=0)
             else:
-                return self.predict(states)
+                return self._predict_as_tensor(states)
 
     def __call__(self, states: torch.Tensor) -> torch.Tensor:
         ans = self.predict_batched(states)

--- a/cayleypy/predictor.py
+++ b/cayleypy/predictor.py
@@ -64,15 +64,18 @@ class Predictor:
         :param states: States (in decoded representation) to apply the model to.
         :return: Output of the model for `states`.
         """
-        num_batches = int(math.ceil(states.shape[0] / self.graph.batch_size))
-        if num_batches > 1:
-            ans = []  # type: list[torch.Tensor]
-            for batch in states.tensor_split(num_batches, dim=0):
-                ans.append(self.predict(batch))
-            # Batches must be concatenated along dimension 0, otherwise outputs of multi-output models are mangled.
-            return torch.cat(ans, dim=0)
-        else:
-            return self.predict(states)
+        # A predictor is only ever used for inference, and building the graph for a backward pass that never happens
+        # costs memory proportional to the size of the model - which is significant when the whole beam is scored.
+        with torch.no_grad():
+            num_batches = int(math.ceil(states.shape[0] / self.graph.batch_size))
+            if num_batches > 1:
+                ans = []  # type: list[torch.Tensor]
+                for batch in states.tensor_split(num_batches, dim=0):
+                    ans.append(self.predict(batch))
+                # Batches must be concatenated along dimension 0, otherwise outputs of multi-output models are mangled.
+                return torch.cat(ans, dim=0)
+            else:
+                return self.predict(states)
 
     def __call__(self, states: torch.Tensor) -> torch.Tensor:
         ans = self.predict_batched(states)

--- a/cayleypy/predictor.py
+++ b/cayleypy/predictor.py
@@ -55,12 +55,52 @@ class Predictor:
         model = PREDICTOR_MODELS[graph.definition.name].load(graph.device)
         return Predictor(graph, model)
 
-    def __call__(self, states: torch.Tensor) -> torch.Tensor:
+    def predict_batched(self, states: torch.Tensor) -> torch.Tensor:
+        """Applies the underlying model to `states`, splitting them into batches if there are too many.
+
+        Output of the model is returned as is. It has shape ``[n_states]`` for usual (single-output) models, and shape
+        ``[n_states, n_outputs]`` for multi-output models (e.g. models predicting one score per generator).
+
+        :param states: States (in decoded representation) to apply the model to.
+        :return: Output of the model for `states`.
+        """
         num_batches = int(math.ceil(states.shape[0] / self.graph.batch_size))
         if num_batches > 1:
             ans = []  # type: list[torch.Tensor]
             for batch in states.tensor_split(num_batches, dim=0):
                 ans.append(self.predict(batch))
-            return torch.hstack(ans)
+            # Batches must be concatenated along dimension 0, otherwise outputs of multi-output models are mangled.
+            return torch.cat(ans, dim=0)
         else:
             return self.predict(states)
+
+    def __call__(self, states: torch.Tensor) -> torch.Tensor:
+        ans = self.predict_batched(states)
+        if len(ans.shape) != 1:
+            raise ValueError(
+                f"Model returned output of shape {tuple(ans.shape)}, but one score per state (1-D output) was "
+                "expected. Models having one output per generator must implement Predictor.score_children instead."
+            )
+        return ans
+
+    def score_children(self, states: torch.Tensor) -> torch.Tensor:
+        """Estimates distances from central state to all children (neighbors) of given states.
+
+        Children are enumerated in the order of generators: element ``[i, j]`` of the answer is the estimated distance
+        for the state obtained by applying generator ``j`` to ``states[i]``.
+
+        This default implementation calls the underlying model for every child, so it needs `n_generators` times more
+        model evaluations than :meth:`__call__`. Models having one output per generator (Q-models) are expected to
+        override this method and compute the whole answer in a single forward pass.
+
+        :param states: States (in decoded representation) whose children to score.
+        :return: Tensor of shape ``[n_states, n_generators]`` with estimated distances for children.
+        """
+        n_generators = self.graph.definition.n_generators
+        encoded_states = self.graph.encode_states(states)
+        num_states = int(encoded_states.shape[0])
+        children = self.graph.decode_states(self.graph.get_neighbors(encoded_states))
+        scores = self(children)
+        # `get_neighbors` returns neighbors in generator-major order: rows [i*num_states, (i+1)*num_states) are children
+        # obtained by applying generator i. Hence, the answer must be transposed.
+        return scores.reshape((n_generators, num_states)).transpose(0, 1).contiguous()

--- a/cayleypy/predictor_test.py
+++ b/cayleypy/predictor_test.py
@@ -109,3 +109,18 @@ def test_score_children_rejects_2d_output():
     predictor = Predictor(graph, MultiOutputModel(graph_def.n_generators))
     with pytest.raises(ValueError, match="score_children"):
         predictor.score_children(torch.tensor([[0, 1, 2, 3, 4]]))
+
+
+def test_predict_batched_does_not_track_gradients():
+    """Test that inference does not build the graph for a backward pass (which would only waste memory)."""
+    graph_def = PermutationGroups.lrx(5)
+    graph = CayleyGraph(graph_def, device="cpu", batch_size=4)
+    model = torch.nn.Sequential(torch.nn.Linear(5, 1), torch.nn.Flatten(0, 1))
+    predictor = Predictor(graph, lambda states: model(states.to(torch.float32)))
+    states = torch.tensor([[i % 5, (i + 1) % 5, 2, 3, 4] for i in range(7)])
+
+    # Weights require gradients, so an output that does not is proof that no graph was built.
+    assert model[0].weight.requires_grad
+    assert not predictor.predict_batched(states).requires_grad
+    assert not predictor(states).requires_grad
+    assert not predictor.score_children(states).requires_grad

--- a/cayleypy/predictor_test.py
+++ b/cayleypy/predictor_test.py
@@ -1,8 +1,20 @@
+import pytest
 import torch
 
 from .cayley_graph import CayleyGraph
 from .graphs_lib import PermutationGroups
 from .predictor import Predictor
+
+
+class MultiOutputModel(torch.nn.Module):
+    """Model returning one score per generator (i.e. having 2-D output)."""
+
+    def __init__(self, n_outputs: int):
+        super().__init__()
+        self.n_outputs = n_outputs
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x[:, :1].float() + torch.arange(self.n_outputs, dtype=torch.float32)
 
 
 def test_hamming_predictor():
@@ -20,3 +32,80 @@ def test_hamming_predictor():
         ]
     )
     assert torch.equal(predictor(states), torch.tensor([2, 3, 0, 5, 3, 2]))
+
+
+def test_predictor_batches_1d_output():
+    graph_def = PermutationGroups.lrx(5)
+    graph = CayleyGraph(graph_def, device="cpu", batch_size=3)
+    predictor = Predictor(graph, "hamming")
+    states = torch.tensor([[i % 5, (i + 1) % 5, 2, 3, 4] for i in range(7)])
+    assert torch.equal(predictor(states), predictor.predict(states))
+
+
+def test_predictor_batches_2d_output():
+    graph_def = PermutationGroups.lrx(5)
+    graph = CayleyGraph(graph_def, device="cpu", batch_size=3)
+    predictor = Predictor(graph, MultiOutputModel(graph_def.n_generators))
+    states = torch.tensor([[i % 5, (i + 1) % 5, 2, 3, 4] for i in range(7)])
+
+    # Batches of a multi-output model must be concatenated along dimension 0.
+    ans = predictor.predict_batched(states)
+    assert ans.shape == (7, graph_def.n_generators)
+    assert torch.equal(ans, predictor.predict(states))
+
+
+def test_predictor_rejects_2d_output():
+    graph_def = PermutationGroups.lrx(5)
+    graph = CayleyGraph(graph_def, device="cpu")
+    predictor = Predictor(graph, MultiOutputModel(graph_def.n_generators))
+    states = torch.tensor([[0, 1, 2, 3, 4], [1, 2, 3, 4, 0]])
+    with pytest.raises(ValueError, match="score_children"):
+        predictor(states)
+
+
+def test_score_children():
+    graph_def = PermutationGroups.lrx(5)
+    graph = CayleyGraph(graph_def, device="cpu")
+    predictor = Predictor(graph, "hamming")
+    states = torch.tensor([[0, 1, 2, 3, 4], [1, 2, 3, 4, 0], [4, 3, 2, 1, 0], [0, 2, 1, 3, 4]])
+
+    scores = predictor.score_children(states)
+    assert scores.shape == (4, graph_def.n_generators)
+    for i in range(graph_def.n_generators):
+        # Column i must contain scores of children obtained by applying generator i.
+        expected = predictor(graph.apply_path(states, [i]))
+        assert torch.equal(scores[:, i], expected)
+
+    # Sanity check that this test can distinguish columns from each other.
+    assert len({tuple(scores[:, i].tolist()) for i in range(graph_def.n_generators)}) > 1
+
+
+def test_score_children_single_state():
+    graph_def = PermutationGroups.lrx(5)
+    graph = CayleyGraph(graph_def, device="cpu")
+    predictor = Predictor(graph, "hamming")
+    scores = predictor.score_children(torch.tensor([0, 2, 1, 3, 4]))
+    assert scores.shape == (1, graph_def.n_generators)
+    for i in range(graph_def.n_generators):
+        assert torch.equal(scores[:, i], predictor(graph.apply_path([0, 2, 1, 3, 4], [i])))
+
+
+def test_score_children_with_batching():
+    graph_def = PermutationGroups.lrx(5)
+    graph = CayleyGraph(graph_def, device="cpu", batch_size=4)
+    predictor = Predictor(graph, "hamming")
+    states = torch.tensor([[i % 5, (i + 1) % 5, 2, 3, 4] for i in range(7)])
+
+    # There are 7*3=21 children, so they are scored in several batches.
+    scores = predictor.score_children(states)
+    assert scores.shape == (7, graph_def.n_generators)
+    for i in range(graph_def.n_generators):
+        assert torch.equal(scores[:, i], predictor(graph.apply_path(states, [i])))
+
+
+def test_score_children_rejects_2d_output():
+    graph_def = PermutationGroups.lrx(5)
+    graph = CayleyGraph(graph_def, device="cpu")
+    predictor = Predictor(graph, MultiOutputModel(graph_def.n_generators))
+    with pytest.raises(ValueError, match="score_children"):
+        predictor.score_children(torch.tensor([[0, 1, 2, 3, 4]]))

--- a/cayleypy/predictor_test.py
+++ b/cayleypy/predictor_test.py
@@ -1,9 +1,18 @@
+import numpy as np
 import pytest
 import torch
 
 from .cayley_graph import CayleyGraph
 from .graphs_lib import PermutationGroups
 from .predictor import Predictor
+
+
+class SklearnStyleModel:
+    """Model with a `predict` method returning a NumPy array, as an sklearn estimator does."""
+
+    @staticmethod
+    def predict(states: torch.Tensor) -> np.ndarray:
+        return np.asarray(states[:, 0], dtype=np.float32)
 
 
 class MultiOutputModel(torch.nn.Module):
@@ -97,6 +106,22 @@ def test_score_children_with_batching():
     states = torch.tensor([[i % 5, (i + 1) % 5, 2, 3, 4] for i in range(7)])
 
     # There are 7*3=21 children, so they are scored in several batches.
+    scores = predictor.score_children(states)
+    assert scores.shape == (7, graph_def.n_generators)
+    for i in range(graph_def.n_generators):
+        assert torch.equal(scores[:, i], predictor(graph.apply_path(states, [i])))
+
+
+@pytest.mark.parametrize("batch_size", [1024, 4])
+def test_predictor_converts_output_of_a_model_not_written_in_torch(batch_size):
+    """A model with a `predict` method is a supported predictor, and sklearn estimators return NumPy arrays."""
+    graph_def = PermutationGroups.lrx(5)
+    graph = CayleyGraph(graph_def, device="cpu", batch_size=batch_size)
+    predictor = Predictor(graph, SklearnStyleModel())
+    states = torch.tensor([[i % 5, (i + 1) % 5, 2, 3, 4] for i in range(7)])
+
+    assert isinstance(predictor.predict_batched(states), torch.Tensor)
+    # score_children applies operations that a NumPy array does not have, so the conversion must happen before them.
     scores = predictor.score_children(states)
     assert scores.shape == (7, graph_def.n_generators)
     for i in range(graph_def.n_generators):

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -43,6 +43,9 @@ Beam search and ML
     cayleypy.algo.BeamSearchResult
     cayleypy.algo.RandomWalksGenerator
     cayleypy.models.ModelConfig
+    cayleypy.models.graph_hash
+    cayleypy.models.save_checkpoint
+    cayleypy.models.load_checkpoint
 
 BFS algorithm and its variations
 ''''''''''''''''''''''''''''''''


### PR DESCRIPTION
First PR of the modelling-layer series (PR1). It only adds the contract and the checkpoint format; the beam search consumer follows in PR2 (`feat/child-scored-beam`).

## Why

- Beam search scores a flat, globally deduplicated set of neighbours, so the "which generator produced this state" link is destroyed before scoring. Models that predict one score per generator (Q-models) cannot be used at all today. `Predictor.score_children` is that missing contract.
- `Predictor.__call__` concatenated batches with `torch.hstack`, which is correct only for 1-D outputs; for a 2-D output it silently glues batches along the wrong dimension.
- Weights are distributed as bare `state_dict` files described by a `ModelConfig` living in library code, so a checkpoint alone does not say what model it belongs to or which graph it was trained for.

## What is in the PR

- `Predictor.score_children(states) -> Tensor[n_states, n_generators]`: element `[i, j]` is the score of the state obtained by applying generator `j` to `states[i]`. The default implementation scores every child and takes into account that `CayleyGraph.get_neighbors` writes neighbours in generator-major order (so the result has to be transposed). Q-models will override this and compute the whole tensor in one forward pass.
- `Predictor.predict_batched`: batching extracted from `__call__` and fixed to concatenate along dimension 0. `__call__` still returns one score per state and now raises a clear error when the model returns something else (instead of mis-ranking states through `argsort` on a 2-D tensor).
- `ModelConfig`: flat additive fields `n_outputs=1`, `tokenizer_groups=None`, `graph_hash=None`, explicitly handled in `from_dict`, plus `to_dict()`. Old configs (and the pretrained models in `PREDICTOR_MODELS`) are unaffected; `MlpModel` rejects `n_outputs != 1` with a clear message until multi-output MLP arrives in PR3.
- The factory `ModelConfig._build_model` is renamed to public `ModelConfig.build_model` (needed by checkpoint loading); it stays in `models.py`, so new model types are still registered there.
- New `cayleypy/models/checkpoint.py`:
  - `save_checkpoint(path, model, config, graph_def=None)` writes `{format_version, config (primitives), state_dict}`;
  - `load_checkpoint(path, device, graph_def=None)` recreates the model from the stored config, calls `torch.load` with an explicit `weights_only=True`, rejects bare state dicts and checkpoints from a newer format version;
  - `graph_hash(graph_def)` hashes only the mathematics of the graph (generator type, generators as permutation lists or `matrix.tolist()` + `modulo`, central state), so renaming a graph does not invalidate checkpoints, but a different graph is detected on load.
- Exports in `cayleypy/__init__.py`, `cayleypy/models/__init__.py` and autosummary entries in `docs/api.rst`.

## Backward compatibility

`Predictor`, `ModelConfig.from_dict`, `ModelConfig.load` and the pretrained models keep working unchanged; `models_lib_test.test_loads_predictor_models` is green. `ModelConfig.load` now passes `weights_only=True` explicitly, which is already the default for the required `torch>=2.6`.

## Tests

- per-column check of `score_children` on `PermutationGroups.lrx(5)` (catches a missing transposition, which a whole-tensor comparison does not), including a single state and a case where children do not fit into one batch;
- 2-D output survives batching; `__call__` and the default `score_children` reject a 2-D output with a clear error;
- `from_dict` with an old dict, `to_dict` round-trip and JSON-serializability, unknown model type, `n_outputs != 1` for MLP;
- checkpoint round-trip (including a matrix group), refusal to load a checkpoint trained for another graph, a bare state dict and an unsupported format version; `graph_hash` determinism, insensitivity to names and sensitivity to generators, central state and modulo.

`./lint.sh` (black, pylint 10.00/10, mypy) and `RUN_SLOW_TESTS=1 pytest` (323 passed) are green on Python 3.12 and on Python 3.9 with torch 2.8 (the CI floor); `docs/build_docs.sh` builds with `-W`.
