### PR TITLE
Add loss functions for training distance-estimating models

### DIFF
--- a/cayleypy/__init__.py
+++ b/cayleypy/__init__.py
@@ -7,3 +7,4 @@ from .datasets import load_dataset
 from .graphs_lib import prepare_graph, PermutationGroups, MatrixGroups
 from .predictor import Predictor
 from .puzzles import Puzzles, GapPuzzles
+from .train import Loss, MseLoss, PinballLoss, make_loss

--- a/cayleypy/train/__init__.py
+++ b/cayleypy/train/__init__.py
@@ -1,0 +1,1 @@
+from .losses import Loss, MseLoss, PinballLoss, make_loss

--- a/cayleypy/train/losses.py
+++ b/cayleypy/train/losses.py
@@ -20,7 +20,6 @@ from typing import Optional
 import torch
 
 
-
 def _check_shape(name: str, tensor: torch.Tensor, predictions: torch.Tensor) -> None:
     if tensor.shape != predictions.shape:
         raise ValueError(

--- a/cayleypy/train/losses.py
+++ b/cayleypy/train/losses.py
@@ -19,10 +19,6 @@ from typing import Optional
 
 import torch
 
-# Lower bound for the denominator of the weighted mean, so that a batch where nothing is labeled gives 0 instead of
-# NaN. Masks are usually indicators, in which case the denominator is a count of labeled elements and never gets
-# anywhere near this value.
-_MIN_DENOMINATOR = 1e-12
 
 
 def _check_shape(name: str, tensor: torch.Tensor, predictions: torch.Tensor) -> None:
@@ -37,13 +33,19 @@ def _weighted_mean(values: torch.Tensor, mask: Optional[torch.Tensor], weights: 
     """Computes mean of values, weighted by mask and weights (either of which may be absent)."""
     element_weight: Optional[torch.Tensor] = None
     if mask is not None:
-        element_weight = mask.to(values.dtype)
+        # Only whether an element is labeled matters, so a mask given as numbers is reduced to an indicator - its
+        # magnitude would otherwise act as a second set of weights.
+        element_weight = (mask != 0).to(values.dtype)
     if weights is not None:
         weights = weights.to(values.dtype)
         element_weight = weights if element_weight is None else element_weight * weights
     if element_weight is None:
         return values.mean()
-    return (values * element_weight).sum() / element_weight.sum().clamp_min(_MIN_DENOMINATOR)
+    # The denominator is kept away from zero so that a batch where nothing is labeled gives 0 instead of NaN. The
+    # smallest positive normal number of the dtype is used because it is representable in all of them - a fixed
+    # constant such as 1e-12 rounds to zero in float16 and leaves the division unguarded.
+    denominator = element_weight.sum().clamp_min(torch.finfo(values.dtype).tiny)
+    return (values * element_weight).sum() / denominator
 
 
 class Loss(abc.ABC):
@@ -97,6 +99,10 @@ class Loss(abc.ABC):
         _check_shape("targets", targets, predictions)
         if mask is not None:
             _check_shape("mask", mask, predictions)
+            # Targets of unlabeled elements are documented to be arbitrary, and a non-finite one would survive being
+            # multiplied by a zero weight (0 * NaN is NaN) and poison both the sum and the gradient. Replacing them
+            # here keeps them out of the graph altogether.
+            targets = torch.where(mask != 0, targets, torch.zeros_like(targets))
         if weights is not None:
             _check_shape("weights", weights, predictions)
         return _weighted_mean(self.elementwise(predictions, targets), mask, weights)

--- a/cayleypy/train/losses.py
+++ b/cayleypy/train/losses.py
@@ -1,0 +1,179 @@
+"""Loss functions for training models that estimate distances in a Cayley graph.
+
+Every loss compares predicted distances with target distances and reduces the per-element differences to a single
+number. Reduction can ignore unlabeled elements (``mask``) and give elements different importance (``weights``).
+
+Example:
+
+>>> import torch
+>>> from cayleypy.train import MseLoss
+>>> predictions = torch.tensor([[1.0, 5.0]])
+>>> targets = torch.tensor([[2.0, 0.0]])
+>>> mask = torch.tensor([[True, False]])
+>>> float(MseLoss()(predictions, targets, mask=mask))
+1.0
+"""
+
+import abc
+from typing import Optional
+
+import torch
+
+# Lower bound for the denominator of the weighted mean, so that a batch where nothing is labeled gives 0 instead of
+# NaN. Masks are usually indicators, in which case the denominator is a count of labeled elements and never gets
+# anywhere near this value.
+_MIN_DENOMINATOR = 1e-12
+
+
+def _check_shape(name: str, tensor: torch.Tensor, predictions: torch.Tensor) -> None:
+    if tensor.shape != predictions.shape:
+        raise ValueError(
+            f"Shape of {name} is {tuple(tensor.shape)}, but it must be the same as shape of predictions, which is "
+            f"{tuple(predictions.shape)}."
+        )
+
+
+def _weighted_mean(values: torch.Tensor, mask: Optional[torch.Tensor], weights: Optional[torch.Tensor]) -> torch.Tensor:
+    """Computes mean of values, weighted by mask and weights (either of which may be absent)."""
+    element_weight: Optional[torch.Tensor] = None
+    if mask is not None:
+        element_weight = mask.to(values.dtype)
+    if weights is not None:
+        weights = weights.to(values.dtype)
+        element_weight = weights if element_weight is None else element_weight * weights
+    if element_weight is None:
+        return values.mean()
+    return (values * element_weight).sum() / element_weight.sum().clamp_min(_MIN_DENOMINATOR)
+
+
+class Loss(abc.ABC):
+    """Base class for losses used to train distance-estimating models.
+
+    Subclasses define the per-element loss in :meth:`elementwise`. Calling the loss computes those values and reduces
+    them to a scalar, which can be backpropagated.
+
+    Losses are not modules (``torch.nn.Module``): they have no learnable parameters, so keeping them out of the module
+    tree keeps checkpoints free of entries that mean nothing at inference time.
+
+    Multi-output (Q-) models predict a distance for every generator, i.e. their predictions have shape
+    ``[batch_size, n_generators]``, and it is common that only some of these outputs are labeled - a state sampled on
+    a random walk has a known target for the generator that produced it, while targets for the other generators are
+    unknown. Passing a ``mask`` of the labeled outputs makes both the loss and the gradient see only those, which is
+    what makes training on such sparse labels possible.
+    """
+
+    @abc.abstractmethod
+    def elementwise(self, predictions: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
+        """Computes loss for every element separately, without reduction.
+
+        :param predictions: Predicted distances.
+        :param targets: Target distances, of the same shape as ``predictions``.
+        :return: Tensor of the same shape as ``predictions``, with loss for every element.
+        """
+
+    def __call__(
+        self,
+        predictions: torch.Tensor,
+        targets: torch.Tensor,
+        mask: Optional[torch.Tensor] = None,
+        weights: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        """Computes mean loss over labeled elements.
+
+        :param predictions: Predicted distances. Shape can be anything, as long as targets, mask and weights have the
+            same shape - e.g. ``[batch_size]`` for a model with a single output, or ``[batch_size, n_generators]`` for
+            a Q-model.
+        :param targets: Target distances, of the same shape as ``predictions``. Values for unlabeled elements (see
+            ``mask``) are ignored, so they can be arbitrary.
+        :param mask: Which elements are labeled (optional), of the same shape as ``predictions``. Nonzero (or True)
+            means "labeled"; unlabeled elements contribute to neither the loss nor the gradient. If None, all elements
+            are labeled.
+        :param weights: Importance of every element (optional), of the same shape as ``predictions``. Weights are used
+            as they are given and are not normalized (the result is the weighted mean, so scaling all of them changes
+            nothing). Useful when some targets are less trustworthy than others - for example, lengths of paths found
+            by beam search are only upper bounds on the true distance. If None, all elements are equally important.
+        :return: Scalar loss - mean of per-element losses over labeled elements, or 0 if nothing is labeled.
+        """
+        _check_shape("targets", targets, predictions)
+        if mask is not None:
+            _check_shape("mask", mask, predictions)
+        if weights is not None:
+            _check_shape("weights", weights, predictions)
+        return _weighted_mean(self.elementwise(predictions, targets), mask, weights)
+
+
+class MseLoss(Loss):
+    """Mean squared error loss.
+
+    This is the default way to regress distances. Because the penalty grows quadratically, a few badly predicted
+    states matter more than many slightly wrong ones.
+
+    Example:
+
+    >>> import torch
+    >>> from cayleypy.train import MseLoss
+    >>> float(MseLoss()(torch.tensor([1.0, 2.0]), torch.tensor([2.0, 2.0])))
+    0.5
+    """
+
+    def elementwise(self, predictions: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
+        """Computes squared error for every element.
+
+        :param predictions: Predicted distances.
+        :param targets: Target distances, of the same shape as ``predictions``.
+        :return: Tensor of the same shape as ``predictions``, with squared errors.
+        """
+        return (predictions - targets.to(predictions.dtype)) ** 2
+
+
+class PinballLoss(Loss):
+    """Pinball (quantile) loss, which penalizes underestimation and overestimation differently.
+
+    A model trained with this loss predicts the ``tau``-quantile of the target distribution instead of its mean. With
+    ``tau > 0.5``, underestimating a distance costs more than overestimating it by the same amount; with
+    ``tau < 0.5``, the other way round, which pushes predictions towards a lower bound on the true distance. At
+    ``tau = 0.5`` this is exactly half of the mean absolute error.
+
+    Example:
+
+    >>> import torch
+    >>> from cayleypy.train import PinballLoss
+    >>> loss = PinballLoss(0.9)
+    >>> float(loss(torch.tensor([1.0, 3.0]), torch.tensor([2.0, 2.0])))
+    0.5
+    """
+
+    def __init__(self, tau: float = 0.5):
+        """Initializes PinballLoss.
+
+        :param tau: Quantile of the target distribution to predict. Must be strictly between 0 and 1.
+        """
+        if not 0.0 < tau < 1.0:
+            raise ValueError(f"tau must be strictly between 0 and 1, got {tau}.")
+        self.tau = float(tau)
+
+    def elementwise(self, predictions: torch.Tensor, targets: torch.Tensor) -> torch.Tensor:
+        """Computes pinball loss for every element.
+
+        :param predictions: Predicted distances.
+        :param targets: Target distances, of the same shape as ``predictions``.
+        :return: Tensor of the same shape as ``predictions``, with pinball losses - ``tau*(target-prediction)`` where
+            the target is underestimated, and ``(1-tau)*(prediction-target)`` where it is overestimated.
+        """
+        difference = targets.to(predictions.dtype) - predictions
+        return torch.maximum(self.tau * difference, (self.tau - 1.0) * difference)
+
+
+def make_loss(name: str, tau: float = 0.5) -> Loss:
+    """Creates loss by name.
+
+    :param name: Name of the loss - either "mse" or "pinball".
+    :param tau: Quantile for the pinball loss (ignored by other losses).
+    :return: The loss.
+    """
+    if name == "mse":
+        return MseLoss()
+    elif name == "pinball":
+        return PinballLoss(tau)
+    else:
+        raise ValueError(f'Unknown loss: "{name}". Supported losses are: "mse", "pinball".')

--- a/cayleypy/train/losses_test.py
+++ b/cayleypy/train/losses_test.py
@@ -1,0 +1,213 @@
+import pytest
+import torch
+
+from .losses import Loss, MseLoss, PinballLoss, make_loss
+
+
+def test_mse_matches_manual_computation():
+    loss = MseLoss()
+    predictions = torch.tensor([1.0, 2.0, 3.0])
+    targets = torch.tensor([1.5, 2.0, 5.0])
+    assert torch.allclose(loss.elementwise(predictions, targets), torch.tensor([0.25, 0.0, 4.0]))
+    assert torch.allclose(loss(predictions, targets), torch.tensor(4.25 / 3))
+
+
+def test_mse_matches_torch():
+    torch.manual_seed(0)
+    predictions = torch.randn(20)
+    targets = torch.randn(20)
+    expected = torch.nn.functional.mse_loss(predictions, targets)
+    assert torch.allclose(MseLoss()(predictions, targets), expected)
+
+
+def test_pinball_at_half_is_half_of_mae():
+    torch.manual_seed(0)
+    predictions = torch.randn(20)
+    targets = torch.randn(20)
+    expected = 0.5 * torch.nn.functional.l1_loss(predictions, targets)
+    assert torch.allclose(PinballLoss(0.5)(predictions, targets), expected)
+
+
+def test_pinball_matches_manual_computation():
+    # Underestimated by 1, exact, overestimated by 2.
+    predictions = torch.tensor([1.0, 2.0, 5.0])
+    targets = torch.tensor([2.0, 2.0, 3.0])
+    loss = PinballLoss(0.8)
+    expected = torch.tensor([0.8 * 1.0, 0.0, 0.2 * 2.0])
+    assert torch.allclose(loss.elementwise(predictions, targets), expected)
+    assert torch.allclose(loss(predictions, targets), expected.mean())
+
+
+def test_pinball_penalizes_underestimation_more_when_tau_is_large():
+    loss = PinballLoss(0.9)
+    target = torch.tensor([10.0])
+    underestimate = loss(torch.tensor([9.0]), target)
+    overestimate = loss(torch.tensor([11.0]), target)
+    assert torch.allclose(underestimate, torch.tensor(0.9))
+    assert torch.allclose(overestimate, torch.tensor(0.1))
+    # And the other way round for a small tau.
+    loss = PinballLoss(0.1)
+    assert torch.allclose(loss(torch.tensor([9.0]), target), torch.tensor(0.1))
+    assert torch.allclose(loss(torch.tensor([11.0]), target), torch.tensor(0.9))
+
+
+def test_pinball_is_minimized_at_the_quantile():
+    loss = PinballLoss(0.75)
+    targets = torch.arange(1, 11).float()
+    candidates = torch.arange(1, 11).float()
+    losses = torch.tensor([float(loss(c.expand(10), targets)) for c in candidates])
+    # 0.75-quantile of 1..10 is 8 (it minimizes the pinball loss uniquely: 9.25 vs 9.75 for 7 and 9).
+    assert float(candidates[int(torch.argmin(losses))]) == 8.0
+
+
+def test_mask_ignores_unlabeled_elements():
+    loss = MseLoss()
+    predictions = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+    targets = torch.tensor([[2.0, 1e9], [-1e9, 6.0]])
+    mask = torch.tensor([[True, False], [False, True]])
+    # Only errors of the labeled elements: (1-2)^2 = 1 and (4-6)^2 = 4.
+    assert torch.allclose(loss(predictions, targets, mask=mask), torch.tensor(2.5))
+
+
+def test_mask_can_be_numeric():
+    loss = MseLoss()
+    predictions = torch.tensor([[1.0, 2.0]])
+    targets = torch.tensor([[2.0, 100.0]])
+    bool_mask = torch.tensor([[True, False]])
+    numeric_mask = torch.tensor([[1.0, 0.0]])
+    assert torch.allclose(loss(predictions, targets, mask=numeric_mask), loss(predictions, targets, mask=bool_mask))
+
+
+def test_mask_blocks_gradient():
+    predictions = torch.tensor([[1.0, 2.0, 3.0]], requires_grad=True)
+    targets = torch.tensor([[2.0, 1e9, 1e9]])
+    mask = torch.tensor([[True, False, False]])
+    MseLoss()(predictions, targets, mask=mask).backward()
+    assert predictions.grad is not None
+    assert float(predictions.grad[0, 0]) != 0.0
+    assert float(predictions.grad[0, 1]) == 0.0
+    assert float(predictions.grad[0, 2]) == 0.0
+
+
+def test_fully_masked_batch_gives_zero_loss_and_zero_gradient():
+    for loss in [MseLoss(), PinballLoss(0.7)]:
+        predictions = torch.tensor([[1.0, 2.0]], requires_grad=True)
+        targets = torch.tensor([[5.0, 5.0]])
+        value = loss(predictions, targets, mask=torch.zeros((1, 2)))
+        assert float(value.detach()) == 0.0
+        value.backward()
+        assert predictions.grad is not None
+        assert not bool(torch.isnan(predictions.grad).any())
+        assert torch.equal(predictions.grad, torch.zeros((1, 2)))
+
+
+def test_weights_give_weighted_mean():
+    loss = MseLoss()
+    predictions = torch.tensor([1.0, 2.0])
+    targets = torch.tensor([2.0, 4.0])
+    # Errors are 1 and 4; weighted mean with weights 3 and 1 is (3*1 + 1*4)/4.
+    weights = torch.tensor([3.0, 1.0])
+    assert torch.allclose(loss(predictions, targets, weights=weights), torch.tensor(7.0 / 4))
+    # Weights are not normalized, but scaling all of them does not change the mean.
+    assert torch.allclose(loss(predictions, targets, weights=weights * 10), torch.tensor(7.0 / 4))
+
+
+def test_weights_combine_with_mask():
+    loss = MseLoss()
+    predictions = torch.tensor([1.0, 2.0, 3.0])
+    targets = torch.tensor([2.0, 4.0, 1e9])
+    mask = torch.tensor([True, True, False])
+    weights = torch.tensor([3.0, 1.0, 100.0])
+    assert torch.allclose(loss(predictions, targets, mask=mask, weights=weights), torch.tensor(7.0 / 4))
+
+
+def test_works_on_q_shaped_predictions():
+    loss = MseLoss()
+    predictions = torch.zeros((7, 3))
+    targets = torch.ones((7, 3))
+    value = loss(predictions, targets)
+    assert value.shape == torch.Size([])
+    assert float(value) == 1.0
+
+
+def test_accepts_integer_targets():
+    # Exact distances computed by BFS are integers.
+    predictions = torch.tensor([1.0, 2.0])
+    targets = torch.tensor([2, 2], dtype=torch.int64)
+    assert torch.allclose(MseLoss()(predictions, targets), torch.tensor(0.5))
+    assert torch.allclose(PinballLoss(0.5)(predictions, targets), torch.tensor(0.25))
+
+
+def test_make_loss():
+    assert isinstance(make_loss("mse"), MseLoss)
+    pinball = make_loss("pinball", tau=0.9)
+    assert isinstance(pinball, PinballLoss)
+    assert pinball.tau == 0.9
+    assert make_loss("pinball").tau == 0.5  # type: ignore[attr-defined]
+    predictions, targets = torch.tensor([1.0]), torch.tensor([2.0])
+    assert torch.equal(make_loss("mse")(predictions, targets), MseLoss()(predictions, targets))
+
+
+def test_training_reduces_loss():
+    for loss in [MseLoss(), PinballLoss(0.5), PinballLoss(0.9)]:
+        torch.manual_seed(42)
+        prediction = torch.zeros(1, requires_grad=True)
+        targets = torch.tensor([3.0, 3.0, 3.0])
+        optimizer = torch.optim.SGD([prediction], lr=0.1)
+        initial_loss = float(loss(prediction.expand(3), targets).detach())
+        for _ in range(100):
+            optimizer.zero_grad()
+            loss(prediction.expand(3), targets).backward()
+            optimizer.step()
+        final_loss = float(loss(prediction.expand(3), targets).detach())
+        assert final_loss < 0.2 * initial_loss
+        assert abs(float(prediction.detach()) - 3.0) < 0.1
+
+
+def test_masked_training_updates_only_labeled_outputs():
+    # Emulates training a Q-model where only one output per state is labeled.
+    torch.manual_seed(42)
+    predictions = torch.zeros((1, 2), requires_grad=True)
+    targets = torch.tensor([[5.0, 5.0]])
+    mask = torch.tensor([[True, False]])
+    optimizer = torch.optim.SGD([predictions], lr=0.1)
+    for _ in range(100):
+        optimizer.zero_grad()
+        MseLoss()(predictions, targets, mask=mask).backward()
+        optimizer.step()
+    assert abs(float(predictions[0, 0].detach()) - 5.0) < 0.1
+    assert float(predictions[0, 1].detach()) == 0.0
+
+
+def test_loss_is_abstract():
+    with pytest.raises(TypeError):
+        Loss()  # type: ignore[abstract]  # pylint: disable=abstract-class-instantiated
+
+
+def test_pinball_rejects_tau_outside_unit_interval():
+    for tau in [0.0, 1.0, -0.5, 1.5, float("nan")]:
+        with pytest.raises(ValueError, match="tau must be strictly between 0 and 1"):
+            PinballLoss(tau)
+
+
+def test_make_loss_rejects_unknown_name():
+    with pytest.raises(ValueError, match="Unknown loss"):
+        make_loss("huber")
+
+
+def test_rejects_targets_of_wrong_shape():
+    with pytest.raises(ValueError, match=r"Shape of targets is \(3,\)"):
+        MseLoss()(torch.zeros(2), torch.zeros(3))
+    with pytest.raises(ValueError, match="same as shape of predictions"):
+        # Same number of elements, but different shape - broadcasting would silently give a wrong answer.
+        PinballLoss()(torch.zeros((2, 3)), torch.zeros((3, 2)))
+
+
+def test_rejects_mask_of_wrong_shape():
+    with pytest.raises(ValueError, match=r"Shape of mask is \(2, 1\)"):
+        MseLoss()(torch.zeros((2, 3)), torch.zeros((2, 3)), mask=torch.ones((2, 1)))
+
+
+def test_rejects_weights_of_wrong_shape():
+    with pytest.raises(ValueError, match=r"Shape of weights is \(2,\)"):
+        MseLoss()(torch.zeros((2, 3)), torch.zeros((2, 3)), weights=torch.ones(2))

--- a/cayleypy/train/losses_test.py
+++ b/cayleypy/train/losses_test.py
@@ -78,6 +78,39 @@ def test_mask_can_be_numeric():
     assert torch.allclose(loss(predictions, targets, mask=numeric_mask), loss(predictions, targets, mask=bool_mask))
 
 
+@pytest.mark.parametrize("bad_target", [float("nan"), float("inf"), float("-inf")])
+def test_mask_ignores_non_finite_targets_of_unlabeled_elements(bad_target):
+    """Targets of unlabeled elements are documented to be arbitrary, and that includes non-finite ones."""
+    loss = MseLoss()
+    predictions = torch.zeros((2, 2), requires_grad=True)
+    targets = torch.tensor([[1.0, bad_target], [2.0, 3.0]])
+    mask = torch.tensor([[True, False], [True, True]])
+    value = loss(predictions, targets, mask=mask)
+    # Only the errors of the labeled elements: 1, 4 and 9, over the 3 of them.
+    assert torch.allclose(value, torch.tensor(14.0 / 3))
+    value.backward()
+    assert predictions.grad is not None
+    assert not bool(torch.isnan(predictions.grad).any())
+    assert float(predictions.grad[0, 1]) == 0.0
+
+
+def test_mask_magnitude_does_not_reweight_labeled_elements():
+    """Nonzero in a mask means "labeled" and nothing else, so a 2 must not count an element twice."""
+    loss = MseLoss()
+    predictions = torch.zeros(2)
+    targets = torch.tensor([1.0, 3.0])
+    indicator = loss(predictions, targets, mask=torch.tensor([1.0, 1.0]))
+    assert torch.allclose(loss(predictions, targets, mask=torch.tensor([1.0, 2.0])), indicator)
+
+
+def test_fully_masked_batch_gives_zero_loss_in_half_precision():
+    """The lower bound on the denominator has to be representable in the dtype of the predictions."""
+    loss = MseLoss()
+    predictions = torch.zeros((1, 2), dtype=torch.float16)
+    targets = torch.ones((1, 2), dtype=torch.float16)
+    assert float(loss(predictions, targets, mask=torch.zeros((1, 2), dtype=torch.float16))) == 0.0
+
+
 def test_mask_blocks_gradient():
     predictions = torch.tensor([[1.0, 2.0, 3.0]], requires_grad=True)
     targets = torch.tensor([[2.0, 1e9, 1e9]])

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -44,6 +44,18 @@ Beam search and ML
     cayleypy.algo.RandomWalksGenerator
     cayleypy.models.ModelConfig
 
+Training
+''''''''
+
+
+.. autosummary::
+    :toctree: generated/
+
+    cayleypy.train.Loss
+    cayleypy.train.MseLoss
+    cayleypy.train.PinballLoss
+    cayleypy.train.make_loss
+
 BFS algorithm and its variations
 ''''''''''''''''''''''''''''''''
 


### PR DESCRIPTION
First piece of the training code: a new `cayleypy.train` package with the losses used to fit models that estimate distance from a state to the central state. Independent of the other PRs in this series — this one branches off `main`.

## What is added

- `MseLoss` — mean squared error, the usual choice for regressing distances.
- `PinballLoss(tau)` — quantile loss. The model predicts the `tau`-quantile of the target distribution instead of its mean, so underestimating and overestimating a distance can be penalized differently: with `tau < 0.5` predictions are pushed towards a lower bound on the true distance, with `tau > 0.5` away from it. At `tau = 0.5` it is exactly half of the mean absolute error.
- `make_loss(name, tau)` — creates either of them by name, so a training config can name its loss.
- `Loss` — the base class; subclasses only implement `elementwise`, and the shared `__call__` does validation and reduction.

## Masking (sparse labels)

Both losses accept an optional `mask` of labeled elements. Multi-output (Q-) models predict a distance for every generator, i.e. predictions have shape `[batch_size, n_generators]`, and labels are usually known for only one or two of them — a state sampled on a random walk has a target for the generator that produced it and nothing for the rest. Masked-out elements contribute to neither the loss nor the gradient, which is what makes training on such sparse labels possible.

Masking is a parameter of both losses rather than a third loss class, because it is orthogonal to the per-element formula: "masked sparse MSE" is just `MseLoss()(predictions, targets, mask=mask)`.

There is also an optional `weights` argument giving the weighted mean, for targets that are less trustworthy than others — lengths of paths found by beam search, for example, are only upper bounds on the true distance. Weights are used as given and are not normalized (scaling all of them changes nothing).

Losses are deliberately not `torch.nn.Module`s: they have no learnable parameters, so keeping them out of the module tree keeps checkpoints free of entries that mean nothing at inference time.

## Tests

26 tests in `cayleypy/train/losses_test.py` (including 3 doctests):

- formulas against manual computation and against `torch.nn.functional` (`pinball` at `tau=0.5` equals half of `l1_loss`; asymmetry for `tau=0.9` and `tau=0.1` with literal expected values; the loss is uniquely minimized at the quantile of the targets);
- masking: unlabeled elements are ignored even when their targets are `1e9`; the gradient is exactly zero at masked positions; a fully masked batch gives loss 0 and a zero (not NaN) gradient; boolean and numeric masks agree;
- weights: weighted mean against manual numbers, no normalization, combination with a mask;
- Q-shaped `[batch, n_generators]` predictions, integer targets (as produced by BFS), scalar output;
- training sanity with a fixed seed: final loss under 20% of the initial one for all three losses; masked training moves only the labeled output and leaves the other one untouched;
- errors: `tau` at 0, 1, negative, above 1 and NaN; unknown loss name; shapes of targets/mask/weights that do not match predictions (including same element count but different shape, where broadcasting would silently give a wrong answer).

## Notes

- No new dependencies.
- `./lint.sh` green (black, pylint 10.00/10, mypy 62 files), repo-wide `black --check .` green, docs build with `-W` green.
- `RUN_SLOW_TESTS=1 pytest` = 322 passed / 12 skipped / 3 xfailed on Python 3.12 and on Python 3.9.
- New symbols are exported from `cayleypy/__init__.py` and listed in a new "Training" section of `docs/api.rst`.

Follow-ups in this series use these: the trainer core, and the sparse-Q / path-based data sources that produce the masks and the sample weights.
