### PR TITLE
Add ResMLP architecture and multi-output (Q-) models

### DIFF
--- a/cayleypy/models/__init__.py
+++ b/cayleypy/models/__init__.py
@@ -1,2 +1,2 @@
 from .checkpoint import graph_hash, load_checkpoint, save_checkpoint
-from .models import ModelConfig
+from .models import MlpModel, ModelConfig, ResMlpModel

--- a/cayleypy/models/models.py
+++ b/cayleypy/models/models.py
@@ -17,10 +17,11 @@ class ModelConfig:
     class. Their defaults describe a single-output model without tokenization, which is not tied to a particular graph,
     so configs written before these fields existed keep working.
 
-    :param model_type: Type of the model, e.g. "MLP".
+    :param model_type: Type of the model, one of "MLP" (see :class:`MlpModel`) or "RESMLP"
+        (see :class:`ResMlpModel`).
     :param input_size: Number of elements in one state.
     :param num_classes_for_one_hot: Number of distinct values one element of a state can take.
-    :param layers_sizes: Sizes of hidden layers.
+    :param layers_sizes: Sizes of hidden layers (for "RESMLP" these are sizes of residual blocks).
     :param weights_kaggle_id: Id of the Kaggle model with weights (optional).
     :param weights_path: Path to the file with weights (optional).
     :param n_outputs: Number of outputs of the model. 1 means the model predicts distance for the state it is applied
@@ -64,6 +65,8 @@ class ModelConfig:
         """Creates model described by this config, with randomly initialized weights."""
         if self.model_type == "MLP":
             return MlpModel(self)
+        elif self.model_type == "RESMLP":
+            return ResMlpModel(self)
         else:
             raise ValueError("Unknown model type: " + self.model_type)
 
@@ -80,18 +83,34 @@ class ModelConfig:
         return model.to(device)
 
 
-class MlpModel(nn.Module):
-    """Multi-layer perceptron model."""
+def _one_hot_encode(states: torch.Tensor, num_classes: int) -> torch.Tensor:
+    """One-hot encodes elements of states and flattens the result, so it can be fed to a fully connected layer."""
+    return nn.functional.one_hot(states.long(), num_classes=num_classes).float().flatten(start_dim=-2)
 
-    def __init__(self, config):
+
+def _validate_n_outputs(config: ModelConfig) -> int:
+    if config.n_outputs < 1:
+        raise ValueError(f"n_outputs must be positive, got {config.n_outputs}.")
+    return config.n_outputs
+
+
+class MlpModel(nn.Module):
+    """Multi-layer perceptron model.
+
+    Consumes one-hot encoded states, applies hidden layers described by `layers_sizes` (each of them being
+    Linear+LayerNorm+ReLU), then a linear output layer with `n_outputs` neurons.
+
+    Output has shape ``[n_states]`` when ``n_outputs == 1``, and shape ``[n_states, n_outputs]`` otherwise.
+    """
+
+    def __init__(self, config: ModelConfig):
         super().__init__()
         assert config.model_type == "MLP"
-        if config.n_outputs != 1:
-            raise ValueError(f"MlpModel supports only n_outputs=1, got {config.n_outputs}.")
+        self.n_outputs = _validate_n_outputs(config)
         self.num_classes_for_one_hot = config.num_classes_for_one_hot
         self.input_layer_size = config.input_size * self.num_classes_for_one_hot
 
-        layers = []
+        layers: list[nn.Module] = []
         in_features = self.input_layer_size
         for hidden_dim in config.layers_sizes:
             layers.append(nn.Linear(in_features, hidden_dim))
@@ -99,9 +118,68 @@ class MlpModel(nn.Module):
             layers.append(nn.ReLU())
             in_features = hidden_dim
 
-        layers.append(nn.Linear(in_features, 1))
+        # For n_outputs=1 this layer has the same shape as before multi-output models were supported, so this model
+        # still loads weights trained back then (including pretrained models from PREDICTOR_MODELS).
+        layers.append(nn.Linear(in_features, self.n_outputs))
         self.layers = nn.Sequential(*layers)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        x = nn.functional.one_hot(x.long(), num_classes=self.num_classes_for_one_hot).float().flatten(start_dim=-2)
-        return self.layers(x).squeeze(-1)
+        ans = self.layers(_one_hot_encode(x, self.num_classes_for_one_hot))
+        # For single-output models the trailing dimension of size 1 is removed, so there is one score per state.
+        return ans.squeeze(-1) if self.n_outputs == 1 else ans
+
+
+class _ResBlock(nn.Module):
+    """Residual block: Linear+LayerNorm+ReLU, adding its input to its output when their shapes match."""
+
+    def __init__(self, in_features: int, out_features: int):
+        super().__init__()
+        self.linear = nn.Linear(in_features, out_features)
+        self.norm = nn.LayerNorm(out_features)
+        self.activation = nn.ReLU()
+        # Skip connection is possible only when input and output of this block have the same number of features.
+        self.has_skip = in_features == out_features
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        ans = self.activation(self.norm(self.linear(x)))
+        return x + ans if self.has_skip else ans
+
+
+class ResMlpModel(nn.Module):
+    """Multi-layer perceptron with residual (skip) connections.
+
+    Deep perceptrons with skip connections are easier to train than plain ones, so this model is usually a better
+    backbone than :class:`MlpModel` when many hidden layers are needed.
+
+    Consumes one-hot encoded states, applies residual blocks described by `layers_sizes` (i.e. there are
+    ``len(layers_sizes)`` blocks and i-th block has ``layers_sizes[i]`` neurons), then a linear output layer with
+    `n_outputs` neurons. Each block is Linear+LayerNorm+ReLU and adds its input to its output. Blocks that change the
+    number of features (e.g. the first block, which consumes the one-hot encoded state) have no skip connection, so
+    ``layers_sizes=[512, 512, 512]`` means one projection followed by two residual blocks.
+
+    Output has shape ``[n_states]`` when ``n_outputs == 1``, and shape ``[n_states, n_outputs]`` otherwise. Setting
+    `n_outputs` to the number of generators of a graph gives a Q-model, which estimates distances for all children of
+    a state in a single forward pass (see :meth:`cayleypy.Predictor.score_children`).
+    """
+
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        assert config.model_type == "RESMLP"
+        if len(config.layers_sizes) == 0:
+            raise ValueError("ResMlpModel needs at least one block, but layers_sizes is empty.")
+        self.n_outputs = _validate_n_outputs(config)
+        self.num_classes_for_one_hot = config.num_classes_for_one_hot
+        self.input_layer_size = config.input_size * self.num_classes_for_one_hot
+
+        blocks: list[nn.Module] = []
+        in_features = self.input_layer_size
+        for hidden_dim in config.layers_sizes:
+            blocks.append(_ResBlock(in_features, hidden_dim))
+            in_features = hidden_dim
+        self.blocks = nn.Sequential(*blocks)
+        self.head = nn.Linear(in_features, self.n_outputs)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        ans = self.head(self.blocks(_one_hot_encode(x, self.num_classes_for_one_hot)))
+        # For single-output models the trailing dimension of size 1 is removed, so there is one score per state.
+        return ans.squeeze(-1) if self.n_outputs == 1 else ans

--- a/cayleypy/models/models_test.py
+++ b/cayleypy/models/models_test.py
@@ -3,7 +3,8 @@ import json
 import pytest
 import torch
 
-from .models import MlpModel, ModelConfig
+from .checkpoint import load_checkpoint, save_checkpoint
+from .models import MlpModel, ModelConfig, ResMlpModel
 
 # Config in the format that existed before n_outputs, tokenizer_groups and graph_hash were added.
 LEGACY_CONFIG_DICT = {
@@ -14,6 +15,9 @@ LEGACY_CONFIG_DICT = {
     "weights_kaggle_id": "fedimser/lrx-16/pyTorch/ep60/1",
     "weights_path": "model_ep60.pth",
 }
+
+# Two states of a graph with input_size=5 and num_classes_for_one_hot=5.
+STATES = torch.tensor([[0, 1, 2, 3, 4], [4, 3, 2, 1, 0]])
 
 
 def test_from_dict_legacy():
@@ -75,8 +79,7 @@ def test_build_mlp_model():
     config = ModelConfig(model_type="MLP", input_size=5, num_classes_for_one_hot=5, layers_sizes=[8, 8])
     model = config.build_model()
     assert isinstance(model, MlpModel)
-    states = torch.tensor([[0, 1, 2, 3, 4], [4, 3, 2, 1, 0]])
-    assert model(states).shape == (2,)
+    assert model(STATES).shape == (2,)
 
 
 def test_build_model_unknown_type():
@@ -87,5 +90,105 @@ def test_build_model_unknown_type():
 
 def test_build_mlp_model_with_multiple_outputs():
     config = ModelConfig(model_type="MLP", input_size=5, num_classes_for_one_hot=5, layers_sizes=[8], n_outputs=3)
-    with pytest.raises(ValueError, match="n_outputs"):
+    model = config.build_model()
+    assert model(STATES).shape == (2, 3)
+
+
+def test_mlp_state_dict_is_backward_compatible():
+    # Weights of pretrained single-output models were saved before multi-output models were supported. Keys and shapes
+    # of the state dict must not change, otherwise those weights stop loading.
+    config = ModelConfig(model_type="MLP", input_size=5, num_classes_for_one_hot=5, layers_sizes=[8, 8])
+    state_dict = config.build_model().state_dict()
+    assert set(state_dict.keys()) == {
+        "layers.0.weight",
+        "layers.0.bias",
+        "layers.1.weight",
+        "layers.1.bias",
+        "layers.3.weight",
+        "layers.3.bias",
+        "layers.4.weight",
+        "layers.4.bias",
+        "layers.6.weight",
+        "layers.6.bias",
+    }
+    assert state_dict["layers.0.weight"].shape == (8, 25)
+    assert state_dict["layers.6.weight"].shape == (1, 8)
+
+
+def test_build_resmlp_model():
+    config = ModelConfig(model_type="RESMLP", input_size=5, num_classes_for_one_hot=5, layers_sizes=[8, 8, 8])
+    model = config.build_model()
+    assert isinstance(model, ResMlpModel)
+    assert model(STATES).shape == (2,)
+
+    # There is one block per element of layers_sizes.
+    assert len(model.blocks) == 3
+
+
+def test_build_resmlp_model_with_multiple_outputs():
+    config = ModelConfig(model_type="RESMLP", input_size=5, num_classes_for_one_hot=5, layers_sizes=[8], n_outputs=3)
+    model = config.build_model()
+    assert model(STATES).shape == (2, 3)
+
+
+def test_resmlp_has_skip_connections():
+    config = ModelConfig(model_type="RESMLP", input_size=5, num_classes_for_one_hot=5, layers_sizes=[8, 8])
+    model = config.build_model()
+
+    # The first block projects the one-hot encoded state (25 features) to 8 features, so it cannot have a skip
+    # connection. All subsequent blocks preserve the number of features, so they have it.
+    assert not model.blocks[0].has_skip
+    assert model.blocks[1].has_skip
+
+    # With zeroed weights, a block with a skip connection is the identity function.
+    block = model.blocks[1]
+    torch.nn.init.zeros_(block.linear.weight)
+    torch.nn.init.zeros_(block.linear.bias)
+    x = torch.rand((4, 8))
+    with torch.no_grad():
+        assert torch.equal(block(x), x)
+
+
+def test_models_are_invariant_to_batch_size():
+    for model_type in ["MLP", "RESMLP"]:
+        config = ModelConfig(
+            model_type=model_type, input_size=5, num_classes_for_one_hot=5, layers_sizes=[8, 8], n_outputs=3
+        )
+        model = config.build_model()
+        model.eval()
+        states = torch.tensor([[i % 5, (i + 1) % 5, 2, 3, 4] for i in range(6)])
+        with torch.no_grad():
+            expected = model(states)
+            for i in range(6):
+                # Batching must not change predictions (up to floating point error of matrix multiplication).
+                assert torch.allclose(model(states[i : i + 1]), expected[i : i + 1], atol=1e-6)
+
+
+def test_checkpoint_round_trip(tmp_path):
+    for model_type in ["MLP", "RESMLP"]:
+        config = ModelConfig(
+            model_type=model_type, input_size=5, num_classes_for_one_hot=5, layers_sizes=[8, 8], n_outputs=3
+        )
+        model = config.build_model()
+        path = tmp_path / (model_type + ".pt")
+        save_checkpoint(path, model, config)
+
+        loaded_model, loaded_config = load_checkpoint(path)
+        assert loaded_config == config
+        with torch.no_grad():
+            assert torch.equal(loaded_model(STATES), model(STATES))
+
+
+def test_build_model_with_non_positive_n_outputs():
+    for model_type in ["MLP", "RESMLP"]:
+        config = ModelConfig(
+            model_type=model_type, input_size=5, num_classes_for_one_hot=5, layers_sizes=[8], n_outputs=0
+        )
+        with pytest.raises(ValueError, match="n_outputs must be positive"):
+            config.build_model()
+
+
+def test_build_resmlp_model_without_blocks():
+    config = ModelConfig(model_type="RESMLP", input_size=5, num_classes_for_one_hot=5, layers_sizes=[])
+    with pytest.raises(ValueError, match="at least one block"):
         config.build_model()

--- a/cayleypy/predictor.py
+++ b/cayleypy/predictor.py
@@ -28,9 +28,15 @@ class Predictor:
             - ``torch.nn.Module`` - will use given neural network model.
             - Any object that has "predict" method (e.g. sklearn models).
             - Any callable object.
+
+            A model estimating distances for all children of a state at once (Q-model) must have as many outputs as
+            there are generators in `graph`, and must declare their number in attribute ``n_outputs`` - then
+            :meth:`score_children` will call it once per state instead of once per child. Models built by
+            :meth:`cayleypy.models.ModelConfig.build_model` declare it automatically.
         """
         self.graph = graph
         self.predict = lambda x: x  # type: Callable[[torch.Tensor], torch.Tensor]
+        self.n_outputs = int(getattr(models_or_heuristics, "n_outputs", 1))
 
         if models_or_heuristics == "zero":
             self.predict = lambda x: torch.zeros((x.shape[0],))
@@ -79,7 +85,7 @@ class Predictor:
         if len(ans.shape) != 1:
             raise ValueError(
                 f"Model returned output of shape {tuple(ans.shape)}, but one score per state (1-D output) was "
-                "expected. Models having one output per generator must implement Predictor.score_children instead."
+                "expected. Models having one output per generator must be used through Predictor.score_children."
             )
         return ans
 
@@ -89,9 +95,11 @@ class Predictor:
         Children are enumerated in the order of generators: element ``[i, j]`` of the answer is the estimated distance
         for the state obtained by applying generator ``j`` to ``states[i]``.
 
-        This default implementation calls the underlying model for every child, so it needs `n_generators` times more
-        model evaluations than :meth:`__call__`. Models having one output per generator (Q-models) are expected to
-        override this method and compute the whole answer in a single forward pass.
+        For a model having one output per generator (Q-model, i.e. ``n_outputs == n_generators``), the answer is the
+        output of the model applied to `states`, so one model evaluation per state is needed.
+
+        Otherwise (for a single-output model), the model is called for every child, which needs `n_generators` times
+        more model evaluations than :meth:`__call__`.
 
         :param states: States (in decoded representation) whose children to score.
         :return: Tensor of shape ``[n_states, n_generators]`` with estimated distances for children.
@@ -99,6 +107,20 @@ class Predictor:
         n_generators = self.graph.definition.n_generators
         encoded_states = self.graph.encode_states(states)
         num_states = int(encoded_states.shape[0])
+        if self.n_outputs != 1:
+            if self.n_outputs != n_generators:
+                raise ValueError(
+                    f"Model has {self.n_outputs} outputs, but the graph has {n_generators} generators. Model used to "
+                    "score children must have either 1 output (for the state it is applied to), or one output per "
+                    "generator (for every child of that state)."
+                )
+            scores = self.predict_batched(self.graph.decode_states(encoded_states))
+            if tuple(scores.shape) != (num_states, n_generators):
+                raise ValueError(
+                    f"Model returned output of shape {tuple(scores.shape)}, but shape "
+                    f"({num_states}, {n_generators}) was expected."
+                )
+            return scores
         children = self.graph.decode_states(self.graph.get_neighbors(encoded_states))
         scores = self(children)
         # `get_neighbors` returns neighbors in generator-major order: rows [i*num_states, (i+1)*num_states) are children

--- a/cayleypy/predictor.py
+++ b/cayleypy/predictor.py
@@ -105,8 +105,11 @@ class Predictor:
         :return: Tensor of shape ``[n_states, n_generators]`` with estimated distances for children.
         """
         n_generators = self.graph.definition.n_generators
-        encoded_states = self.graph.encode_states(states)
-        num_states = int(encoded_states.shape[0])
+        # The model consumes states in decoded representation, so they are only brought to the expected shape here. The
+        # internal representation is computed below, where it is needed - for `get_neighbors`.
+        decoded_shape = (-1,) + self.graph.definition.decoded_state_shape
+        states = torch.as_tensor(states, device=self.graph.device).reshape(decoded_shape)
+        num_states = int(states.shape[0])
         if self.n_outputs != 1:
             if self.n_outputs != n_generators:
                 raise ValueError(
@@ -114,14 +117,14 @@ class Predictor:
                     "score children must have either 1 output (for the state it is applied to), or one output per "
                     "generator (for every child of that state)."
                 )
-            scores = self.predict_batched(self.graph.decode_states(encoded_states))
+            scores = self.predict_batched(states)
             if tuple(scores.shape) != (num_states, n_generators):
                 raise ValueError(
                     f"Model returned output of shape {tuple(scores.shape)}, but shape "
                     f"({num_states}, {n_generators}) was expected."
                 )
             return scores
-        children = self.graph.decode_states(self.graph.get_neighbors(encoded_states))
+        children = self.graph.decode_states(self.graph.get_neighbors(self.graph.encode_states(states)))
         scores = self(children)
         # `get_neighbors` returns neighbors in generator-major order: rows [i*num_states, (i+1)*num_states) are children
         # obtained by applying generator i. Hence, the answer must be transposed.

--- a/cayleypy/predictor_test.py
+++ b/cayleypy/predictor_test.py
@@ -3,6 +3,7 @@ import torch
 
 from .cayley_graph import CayleyGraph
 from .graphs_lib import PermutationGroups
+from .models import ModelConfig
 from .predictor import Predictor
 
 
@@ -103,9 +104,95 @@ def test_score_children_with_batching():
         assert torch.equal(scores[:, i], predictor(graph.apply_path(states, [i])))
 
 
-def test_score_children_rejects_2d_output():
+class HammingQModel(torch.nn.Module):
+    """Q-model equivalent to the "hamming" heuristic: output j is Hamming distance of the j-th child."""
+
+    def __init__(self, graph: CayleyGraph):
+        super().__init__()
+        self.graph = graph
+        self.n_outputs = graph.definition.n_generators
+        self.num_calls = 0
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        self.num_calls += 1
+        children = [self.graph.apply_path(x, [i]) for i in range(self.n_outputs)]
+        return torch.stack([torch.sum(child != self.graph.central_state, dim=1) for child in children], dim=1)
+
+
+def test_score_children_uses_q_model():
     graph_def = PermutationGroups.lrx(5)
     graph = CayleyGraph(graph_def, device="cpu")
-    predictor = Predictor(graph, MultiOutputModel(graph_def.n_generators))
-    with pytest.raises(ValueError, match="score_children"):
+    states = torch.tensor([[0, 1, 2, 3, 4], [1, 2, 3, 4, 0], [4, 3, 2, 1, 0], [0, 2, 1, 3, 4]])
+    model = HammingQModel(graph)
+    q_predictor = Predictor(graph, model)
+    scalar_predictor = Predictor(graph, "hamming")
+
+    scores = q_predictor.score_children(states)
+    assert scores.shape == (4, graph_def.n_generators)
+
+    # A Q-model and its scalar equivalent must give the same scores, column by column.
+    expected = scalar_predictor.score_children(states)
+    for i in range(graph_def.n_generators):
+        assert torch.equal(scores[:, i], expected[:, i])
+
+    # Sanity check that this test can distinguish columns from each other.
+    assert len({tuple(scores[:, i].tolist()) for i in range(graph_def.n_generators)}) > 1
+
+    # The whole answer was computed by a single call to the model (the scalar path needs one call per generator).
+    assert model.num_calls == 1
+
+
+def test_score_children_by_q_model_with_batching():
+    graph_def = PermutationGroups.lrx(5)
+    graph = CayleyGraph(graph_def, device="cpu", batch_size=3)
+    states = torch.tensor([[i % 5, (i + 1) % 5, 2, 3, 4] for i in range(7)])
+    predictor = Predictor(graph, HammingQModel(graph))
+
+    scores = predictor.score_children(states)
+    assert scores.shape == (7, graph_def.n_generators)
+    for i in range(graph_def.n_generators):
+        assert torch.equal(scores[:, i], Predictor(graph, "hamming")(graph.apply_path(states, [i])))
+
+
+def test_score_children_rejects_wrong_number_of_outputs():
+    graph_def = PermutationGroups.lrx(5)
+    graph = CayleyGraph(graph_def, device="cpu")
+    predictor = Predictor(graph, MultiOutputModel(graph_def.n_generators + 1))
+    with pytest.raises(ValueError, match="but the graph has 3 generators"):
+        predictor.score_children(torch.tensor([[0, 1, 2, 3, 4]]))
+
+
+def test_score_children_with_q_model_from_config():
+    graph_def = PermutationGroups.lrx(5)
+    graph = CayleyGraph(graph_def, device="cpu")
+    config = ModelConfig(
+        model_type="RESMLP",
+        input_size=5,
+        num_classes_for_one_hot=5,
+        layers_sizes=[8, 8],
+        n_outputs=graph_def.n_generators,
+    )
+
+    # Models built from a config declare their number of outputs, so no wrapper is needed to use them as Q-models.
+    predictor = Predictor(graph, config.build_model())
+    scores = predictor.score_children(torch.tensor([[0, 1, 2, 3, 4], [1, 2, 3, 4, 0]]))
+    assert scores.shape == (2, graph_def.n_generators)
+
+
+class WrongShapeModel(torch.nn.Module):
+    """Model that declares one output per generator, but returns one score per state."""
+
+    def __init__(self, n_outputs: int):
+        super().__init__()
+        self.n_outputs = n_outputs
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.zeros((x.shape[0],))
+
+
+def test_score_children_rejects_wrong_output_shape():
+    graph_def = PermutationGroups.lrx(5)
+    graph = CayleyGraph(graph_def, device="cpu")
+    predictor = Predictor(graph, WrongShapeModel(graph_def.n_generators))
+    with pytest.raises(ValueError, match=r"but shape \(1, 3\) was expected"):
         predictor.score_children(torch.tensor([[0, 1, 2, 3, 4]]))

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -43,6 +43,8 @@ Beam search and ML
     cayleypy.algo.BeamSearchResult
     cayleypy.algo.RandomWalksGenerator
     cayleypy.models.ModelConfig
+    cayleypy.models.MlpModel
+    cayleypy.models.ResMlpModel
     cayleypy.models.graph_hash
     cayleypy.models.save_checkpoint
     cayleypy.models.load_checkpoint


### PR DESCRIPTION
PR3 of the CayleyPy integration series (base = `feat/score-children-contract` from PR #1; Draft until that one is merged).

`ModelConfig.n_outputs`, added in #1 together with the `score_children` contract, was accepted by the config but no model could be built with it. This PR adds such models.

## What is added

- **`MlpModel` with `n_outputs > 1`.** For `n_outputs=1` keys and shapes of its state dict are exactly as before, so weights of pretrained models from `PREDICTOR_MODELS` still load — pinned by `test_mlp_state_dict_is_backward_compatible` and by `models_lib_test.test_loads_predictor_models` (green, downloads real Kaggle weights).
- **`ResMlpModel`** (model type `"RESMLP"`, registered in `ModelConfig.build_model`): residual blocks of Linear+LayerNorm+ReLU followed by a linear output layer. `layers_sizes` describes the blocks: there are `len(layers_sizes)` of them, and i-th one has `layers_sizes[i]` neurons. A block adds its input to its output, except blocks that change the number of features (e.g. the first one, which consumes the one-hot encoded state) — so `layers_sizes=[512, 512, 512]` is one projection plus two residual blocks. Deep MLPs with skip connections are easier to train, which matters for the trainer coming later in the series.
- **Fast path in `Predictor.score_children`.** When the model declares `n_outputs == n_generators` (a Q-model), children of a state are scored by one forward pass on the parent, instead of one pass per child — `n_generators` times fewer model evaluations. Dispatch uses the `n_outputs` attribute of the model, which models built by `ModelConfig.build_model` set automatically; this is the semantics documented for `ModelConfig.n_outputs` in #1.

## Notes

- Weights are here: #11 registers a `ResMlpModel` Q-model for "lrx-14", trained with the trainer (#9, #10), in `PREDICTOR_MODELS` — it solves 50 out of 50 random states at beam width 1000, where the Hamming heuristic solves none. So this is not dead code.
- Scope deviation from the plan: `predictor.py` had to be touched too, because `score_children` (where the fast path belongs) lives there.
- One existing test changed meaning: `test_score_children_rejects_2d_output` asserted that a multi-output model cannot score children — exactly the limitation this PR lifts. It is replaced by `test_score_children_rejects_wrong_number_of_outputs` (`n_outputs` mismatching the graph) plus tests of the new path.

## Tests

12 new tests: output shapes for both architectures with 1 and 3 outputs, state dict compatibility, skip connections (a block with zeroed weights is the identity function), invariance to batch size, checkpoint round-trip for both types, per-column equality of the fast path and the default path (Hamming Q-model vs the `"hamming"` heuristic, plus an assertion that the model was called once), Q-model built from a config, and errors for non-positive `n_outputs`, empty `layers_sizes`, `n_outputs` mismatching the graph, and output shape contradicting the declared `n_outputs`.

`./lint.sh` green (black, pylint 10.00/10, mypy), `black --check .` green, `docs/build_docs.sh` (`-W`) green, `RUN_SLOW_TESTS=1 pytest` = 335 passed / 12 skipped / 3 xfailed on Python 3.12 (torch 2.13) and on Python 3.9 (torch 2.8).



---

Based on #191, which is the base branch of this PR, so this diff is only its own change. #191 should be merged first.
