### PR TITLE
Score children of beam states through their parents

### DIFF
--- a/cayleypy/algo/beam_search.py
+++ b/cayleypy/algo/beam_search.py
@@ -1,7 +1,7 @@
 """Beam search algorithm for Cayley graphs."""
 
 import time
-from typing import TYPE_CHECKING, Optional
+from typing import NamedTuple, TYPE_CHECKING, Optional
 
 import numpy as np
 import torch
@@ -14,6 +14,74 @@ from ..torch_utils import isin_via_searchsorted
 
 if TYPE_CHECKING:
     from ..cayley_graph import CayleyGraph
+
+
+class _ExpandedLayer(NamedTuple):
+    """States obtained by applying all generators to states of the current layer, with duplicates removed.
+
+    All fields are parallel arrays, indexed by position of a state on the next layer.
+    """
+
+    states: torch.Tensor
+    """Unique states of the next layer (in internal representation)."""
+
+    hashes: torch.Tensor
+    """Hashes of `states`."""
+
+    moves: torch.Tensor
+    """Id of the generator that produced each state.
+
+    This is the provenance of a state, which is lost when the next layer is deduplicated as a flat set of states.
+    """
+
+    source_index: torch.Tensor
+    """Index of each state in the output of `CayleyGraph.get_neighbors`, used to look up score of that state."""
+
+
+def _expand_layer(graph: "CayleyGraph", states: torch.Tensor) -> _ExpandedLayer:
+    """Applies all generators to `states` and removes duplicates, remembering where each state came from.
+
+    This is a variant of `CayleyGraph.get_unique_states` that additionally keeps the link between a state on the next
+    layer and the generator that produced it. Deduplication is the same: states are sorted by hash, and the first
+    state with each hash is kept.
+
+    :param graph: The Cayley graph.
+    :param states: States of the current layer (in internal representation).
+    :return: States of the next layer, with provenance of each state.
+    """
+    n_states = int(states.shape[0])
+    neighbors = graph.get_neighbors(states)
+    hashes = graph.hasher.make_hashes(neighbors)
+    hashes_sorted, idx = torch.sort(hashes, stable=True)
+    # Compute mask of first occurrences for each unique value.
+    mask = torch.ones(hashes_sorted.size(0), dtype=torch.bool, device=hashes_sorted.device)
+    if hashes_sorted.size(0) > 1:
+        mask[1:] = hashes_sorted[1:] != hashes_sorted[:-1]
+    unique_idx = idx[mask]
+    # `get_neighbors` writes neighbors in generator-major order: rows [i*n_states, (i+1)*n_states) are obtained by
+    # applying generator i, so the id of that generator is the row index divided by the number of states.
+    moves = torch.div(unique_idx, n_states, rounding_mode="floor")
+    return _ExpandedLayer(neighbors[unique_idx], hashes[unique_idx], moves, unique_idx)
+
+
+def _score_children(graph: "CayleyGraph", predictor: Predictor, states: torch.Tensor) -> torch.Tensor:
+    """Estimates scores of all children of `states`, calling the predictor once per state (not once per child).
+
+    :param graph: The Cayley graph.
+    :param predictor: A heuristic that estimates scores for states.
+    :param states: States of the current layer (in internal representation).
+    :return: Scores of all children, flattened in the same order in which `CayleyGraph.get_neighbors` returns them.
+    """
+    n_states = int(states.shape[0])
+    n_generators = graph.definition.n_generators
+    scores = predictor.score_children(graph.decode_states(states))
+    if tuple(scores.shape) != (n_states, n_generators):
+        raise ValueError(
+            f"score_children returned scores of shape {tuple(scores.shape)}, but shape {(n_states, n_generators)} "
+            "was expected. Model used with child scoring must have exactly one output per generator."
+        )
+    # `score_children` returns scores state-major, while `get_neighbors` returns children generator-major.
+    return scores.transpose(0, 1).reshape(-1)
 
 
 class BeamSearchAlgorithm:
@@ -43,6 +111,7 @@ class BeamSearchAlgorithm:
         history_depth: int = 0,
         return_path: bool = False,
         bfs_result_for_mitm: Optional[BfsResult] = None,
+        use_child_scores: bool = False,
         verbose: int = 0,
     ) -> BeamSearchResult:
         """Tries to find a path from `start_state` to destination state using Beam Search algorithm.
@@ -67,6 +136,8 @@ class BeamSearchAlgorithm:
         :param return_path: For "simple" mode, whether to return path (consumes much more memory if True).
         :param bfs_result_for_mitm: For "simple" mode, BfsResult with pre-computed neighborhood of central state
             for meet-in-the-middle optimization. Defaults to None.
+        :param use_child_scores: For "simple" mode, whether to score states using `Predictor.score_children`
+            (see :meth:`search_simple`). Defaults to False.
         :param verbose: Verbosity level (0=quiet, 1=basic, 10=detailed, 100=profiling).
         :return: BeamSearchResult containing found path length and (optionally) the path itself.
         """
@@ -78,8 +149,11 @@ class BeamSearchAlgorithm:
                 max_steps=max_steps,
                 return_path=return_path,
                 bfs_result_for_mitm=bfs_result_for_mitm,
+                use_child_scores=use_child_scores,
             )
         elif beam_mode == "advanced":
+            if use_child_scores:
+                raise ValueError("use_child_scores is supported only in 'simple' beam mode.")
             return self.search_advanced(
                 start_state=start_state,
                 destination_state=destination_state,
@@ -101,6 +175,7 @@ class BeamSearchAlgorithm:
         max_steps=1000,
         return_path=False,
         bfs_result_for_mitm: Optional[BfsResult] = None,
+        use_child_scores: bool = False,
     ) -> BeamSearchResult:
         """Tries to find a path from `start_state` to central state using simple Beam Search algorithm.
 
@@ -114,6 +189,11 @@ class BeamSearchAlgorithm:
             meet-in-the-middle modification of Beam Search. Beam search will terminate when any of states in that
             neighborhood is encountered. Defaults to None, which means no meet-in-the-middle (i.e. only search for the
             central state).
+        :param use_child_scores: Whether to score states on the next layer with `Predictor.score_children` applied to
+            states on the current layer, instead of applying the predictor to the states on the next layer themselves.
+            Scores are the same, but the predictor is called once per state of the current layer instead of once per
+            state of the next layer, which is much cheaper for models having one output per generator (Q-models).
+            Defaults to False, which means the predictor is applied to states on the next layer.
         :return: BeamSearchResult containing found path length and (optionally) the path itself.
         """
         graph = self.graph
@@ -157,8 +237,13 @@ class BeamSearchAlgorithm:
             return path1 + path2
 
         for i in range(max_steps):
-            # Create states on the next layer.
-            layer2, layer2_hashes = graph.get_unique_states(graph.get_neighbors(layer1))
+            # Create states on the next layer. When children are scored through their parents, we additionally need to
+            # know which (state, generator) pair produced each state of the next layer.
+            expanded = _expand_layer(graph, layer1) if use_child_scores else None
+            if expanded is not None:
+                layer2, layer2_hashes = expanded.states, expanded.hashes
+            else:
+                layer2, layer2_hashes = graph.get_unique_states(graph.get_neighbors(layer1))
 
             bfs_layer_id = _check_path_found(layer2_hashes)
             if bfs_layer_id != -1:
@@ -168,7 +253,10 @@ class BeamSearchAlgorithm:
 
             # Pick `beam_width` states with lowest scores.
             if len(layer2) >= beam_width:
-                scores = predictor(graph.decode_states(layer2))
+                if expanded is not None:
+                    scores = _score_children(graph, predictor, layer1)[expanded.source_index]
+                else:
+                    scores = predictor(graph.decode_states(layer2))
                 idx = torch.argsort(scores)[:beam_width]
                 layer2 = layer2[idx, :]
                 layer2_hashes = layer2_hashes[idx]

--- a/cayleypy/algo/beam_search_test.py
+++ b/cayleypy/algo/beam_search_test.py
@@ -200,8 +200,9 @@ def test_beam_search_simple_child_scores_same_as_default():
 
     _validate_beam_search_result(graph, start_state, result1)
     assert result1.path == result2.path
-    # Scores are recorded on every step where the beam was truncated, so this compares whole beams, not only the
-    # answer. Hamming distance is computed in integer arithmetic, so scores must match exactly.
+    # One score is recorded per step where the beam was truncated - the best score of that step - so this compares the
+    # two searches step by step, not only their answers. Hamming distance is computed in integer arithmetic, so the
+    # scores must match exactly.
     assert len(result1.debug_scores) > 0
     assert result1.debug_scores == result2.debug_scores
 

--- a/cayleypy/algo/beam_search_test.py
+++ b/cayleypy/algo/beam_search_test.py
@@ -10,6 +10,7 @@ from ..cayley_graph import CayleyGraph
 
 from ..graphs_lib import PermutationGroups, MatrixGroups, prepare_graph
 from ..predictor import Predictor
+from .beam_search import _expand_layer, _score_children
 from .beam_search_result import BeamSearchResult
 
 RUN_SLOW_TESTS = os.getenv("RUN_SLOW_TESTS") == "1"
@@ -26,6 +27,37 @@ def _validate_beam_search_result(graph: CayleyGraph, start_state, bs_result: Bea
 def _scramble(graph: CayleyGraph, num_scrambles: int) -> torch.Tensor:
     """Create a scrambled state by applying random moves."""
     return graph.random_walks(width=1, length=num_scrambles + 1)[0][-1]
+
+
+class _ChildrenHammingModel(torch.nn.Module):
+    """Emulates a Q-model: returns Hamming distances of all children of a state, one output per generator."""
+
+    def __init__(self, graph: CayleyGraph):
+        super().__init__()
+        self.permutations = torch.as_tensor(graph.definition.generators_permutations, device=graph.device)
+        self.central_state = graph.central_state
+
+    def forward(self, states: torch.Tensor) -> torch.Tensor:
+        # children[i, j, :] is the state obtained by applying generator j to states[i].
+        children = states[:, self.permutations]
+        return torch.sum(children != self.central_state, dim=2)
+
+
+class _ChildrenHammingPredictor(Predictor):
+    """Predictor for a model that has one output per generator."""
+
+    def __init__(self, graph: CayleyGraph):
+        super().__init__(graph, _ChildrenHammingModel(graph))
+
+    def score_children(self, states: torch.Tensor) -> torch.Tensor:
+        return self.predict_batched(states)
+
+
+class _BrokenChildrenPredictor(Predictor):
+    """Predictor whose model has wrong number of outputs (one more than the number of generators)."""
+
+    def score_children(self, states: torch.Tensor) -> torch.Tensor:
+        return torch.zeros((states.shape[0], self.graph.definition.n_generators + 1))
 
 
 # =============================================================================
@@ -114,6 +146,119 @@ def test_beam_search_simple_not_found():
     start_state = np.random.permutation(n)
     bs_result = graph.beam_search(start_state=start_state, beam_mode="simple", beam_width=10, max_steps=10)
     assert not bs_result.path_found
+
+
+# =============================================================================
+# Tests for child scoring in "simple" beam search mode
+# =============================================================================
+
+
+def test_expand_layer_keeps_provenance():
+    """Test that layer expansion deduplicates as usual, but remembers which generator produced each state."""
+    graph = CayleyGraph(PermutationGroups.lrx(5), device="cpu")
+    parents = graph.encode_states([[0, 1, 2, 3, 4], [1, 0, 2, 3, 4], [2, 3, 4, 0, 1]])
+    n_parents = int(parents.shape[0])
+
+    expanded = _expand_layer(graph, parents)
+
+    expected_states, expected_hashes = graph.get_unique_states(graph.get_neighbors(parents))
+    assert torch.equal(expanded.states, expected_states)
+    assert torch.equal(expanded.hashes, expected_hashes)
+
+    # Applying generator `moves[i]` to the state that produced i-th state must give exactly that state.
+    decoded_parents = graph.decode_states(parents)
+    assert len(expanded.moves) == len(expanded.states)
+    for i in range(len(expanded.states)):
+        parent_id = int(expanded.source_index[i]) % n_parents
+        child = graph.apply_path(decoded_parents[parent_id], [int(expanded.moves[i])])
+        assert torch.equal(graph.encode_states(child), expanded.states[i : i + 1])
+
+
+def test_expand_layer_empty_frontier():
+    """Test that expanding and scoring an empty layer gives empty answers rather than an error."""
+    graph = CayleyGraph(PermutationGroups.lrx(5), device="cpu")
+    no_states = torch.zeros((0, graph.encoded_state_size), dtype=torch.int64)
+
+    expanded = _expand_layer(graph, no_states)
+    assert expanded.states.shape == (0, graph.encoded_state_size)
+    assert len(expanded.hashes) == 0
+    assert len(expanded.moves) == 0
+    assert len(expanded.source_index) == 0
+
+    assert len(_score_children(graph, _ChildrenHammingPredictor(graph), no_states)) == 0
+
+
+def test_beam_search_simple_child_scores_same_as_default():
+    """Test that child scoring with the same predictor gives exactly the same beam."""
+    graph = CayleyGraph(PermutationGroups.lrx(8), device="cpu")
+    start_state = [3, 0, 2, 4, 5, 6, 7, 1]
+
+    result1 = graph.beam_search(start_state=start_state, beam_width=10, max_steps=50, return_path=True)
+    result2 = graph.beam_search(
+        start_state=start_state, beam_width=10, max_steps=50, return_path=True, use_child_scores=True
+    )
+
+    _validate_beam_search_result(graph, start_state, result1)
+    assert result1.path == result2.path
+    # Scores are recorded on every step where the beam was truncated, so this compares whole beams, not only the
+    # answer. Hamming distance is computed in integer arithmetic, so scores must match exactly.
+    assert len(result1.debug_scores) > 0
+    assert result1.debug_scores == result2.debug_scores
+
+
+def test_beam_search_simple_child_scores_same_as_default_when_path_not_found():
+    """Test that child scoring does not change the beam even on a long unsuccessful search."""
+    graph = CayleyGraph(PermutationGroups.lrx(8), device="cpu")
+    start_state = [7, 6, 5, 4, 3, 2, 1, 0]
+
+    result1 = graph.beam_search(start_state=start_state, beam_width=20, max_steps=50)
+    result2 = graph.beam_search(start_state=start_state, beam_width=20, max_steps=50, use_child_scores=True)
+
+    assert not result1.path_found
+    assert not result2.path_found
+    assert len(result1.debug_scores) > 40
+    assert result1.debug_scores == result2.debug_scores
+
+
+def test_beam_search_simple_child_scores_q_model_parity():
+    """Test that a model with one output per generator gives the same beam as its scalar equivalent."""
+    graph = CayleyGraph(PermutationGroups.lrx(8), device="cpu")
+    start_state = [3, 0, 2, 4, 5, 6, 7, 1]
+
+    result_scalar = graph.beam_search(
+        start_state=start_state, predictor=Predictor(graph, "hamming"), beam_width=10, max_steps=50, return_path=True
+    )
+    result_q = graph.beam_search(
+        start_state=start_state,
+        predictor=_ChildrenHammingPredictor(graph),
+        beam_width=10,
+        max_steps=50,
+        return_path=True,
+        use_child_scores=True,
+    )
+
+    _validate_beam_search_result(graph, start_state, result_q)
+    assert result_scalar.path == result_q.path
+    assert result_scalar.debug_scores == result_q.debug_scores
+
+
+def test_beam_search_simple_child_scores_wrong_number_of_outputs():
+    """Test that a model with wrong number of outputs is reported clearly."""
+    graph = CayleyGraph(PermutationGroups.lrx(8), device="cpu")
+    predictor = _BrokenChildrenPredictor(graph, "zero")
+
+    with pytest.raises(ValueError, match="one output per generator"):
+        graph.beam_search(
+            start_state=[7, 6, 5, 4, 3, 2, 1, 0], beam_width=3, max_steps=50, use_child_scores=True, predictor=predictor
+        )
+
+
+def test_beam_search_child_scores_not_supported_in_advanced_mode():
+    """Test that child scoring is rejected in "advanced" mode, where it is not implemented."""
+    graph = CayleyGraph(PermutationGroups.lrx(5), device="cpu")
+
+    with pytest.raises(ValueError, match="only in 'simple' beam mode"):
+        graph.beam_search(start_state=[4, 1, 0, 2, 3], beam_mode="advanced", use_child_scores=True)
 
 
 # =============================================================================


### PR DESCRIPTION
Second PR of the series (base = `feat/score-children-contract`, PR #1). Draft until #1 is merged.

PR #1 added the `Predictor.score_children` contract; this PR gives it a consumer, so the contract is not dead code.

## What

New option `use_child_scores` (default `False`) for `beam_mode="simple"`. When set, states of the next layer are scored by applying `Predictor.score_children` to states of the *current* layer, instead of applying the predictor to the states of the next layer themselves.

Scores are identical, but the predictor is called once per state of the current layer instead of once per child. For a model with one output per generator (Q-model) that is one forward pass instead of `n_generators` passes.

## How

The next layer is built by `_expand_layer`, which deduplicates exactly as `CayleyGraph.get_unique_states` does (sort by hash, keep first occurrence), but additionally returns:

* `source_index` — index of each surviving state in the output of `get_neighbors`, used to look up its score;
* `moves` — id of the generator that produced each state.

`get_neighbors` writes children generator-major, while `score_children` returns them state-major, so scores are transposed before being flattened into `get_neighbors` order. Keeping this provenance is the point: today the next layer is deduplicated as a flat set of states, which destroys the parent → move link. That link is needed by the two follow-up PRs (canonical deduplication and non-backtracking for `search_simple`).

A model whose `score_children` returns something other than `[n_states, n_generators]` is reported with a clear error.

## Scope

Only `beam_mode="simple"`; `use_child_scores=True` with `"advanced"` raises. In "advanced" mode states are additionally filtered against hashes of previous levels (which would have to re-index the scores), and that loop is being rewritten in #157 upstream. `search_simple` is also where the follow-up PRs need the provenance.

Default behaviour is unchanged: with `use_child_scores=False` the code path is exactly the old one, and existing tests are untouched.

## Tests

* `use_child_scores=True` with the default predictor gives exactly the same beam as the old path — the found path and the per-step best scores match, both on a successful search and on a 50-step unsuccessful one (Hamming distance is integer arithmetic, so equality is exact).
* Parity: a model with one output per generator (Hamming distances of all children in one call) and its scalar equivalent produce identical beams on `lrx(8)`.
* Provenance: for every state of the expanded layer, applying `moves[i]` to the parent it came from reproduces that state; states and hashes equal those of `get_unique_states`.
* Errors/edges: wrong number of model outputs; `use_child_scores` in "advanced" mode; empty layer.

`./lint.sh` and `RUN_SLOW_TESTS=1 pytest` are green (330 passed / 12 skipped / 3 xfailed) on Python 3.12 and on Python 3.9 (torch 2.8); `black --check .` and `docs/build_docs.sh` are green.


---

Based on #191, which is the base branch of this PR, so this diff is only its own change. #191 should be merged first.
