### PR TITLE
Add GroupTokenizer for models consuming states as sequences of tokens

### DIFF
--- a/cayleypy/__init__.py
+++ b/cayleypy/__init__.py
@@ -5,6 +5,6 @@ from .cayley_path import CayleyPath
 from .create_graph import create_graph
 from .datasets import load_dataset
 from .graphs_lib import prepare_graph, PermutationGroups, MatrixGroups
-from .models import ModelConfig, load_checkpoint, save_checkpoint
+from .models import GroupTokenizer, ModelConfig, load_checkpoint, save_checkpoint
 from .predictor import Predictor
 from .puzzles import Puzzles, GapPuzzles

--- a/cayleypy/models/__init__.py
+++ b/cayleypy/models/__init__.py
@@ -1,2 +1,3 @@
 from .checkpoint import graph_hash, load_checkpoint, save_checkpoint
 from .models import ModelConfig
+from .tokenizer import GroupTokenizer

--- a/cayleypy/models/tokenizer.py
+++ b/cayleypy/models/tokenizer.py
@@ -1,0 +1,169 @@
+"""Tokenization of states for models that process them as sequences of tokens."""
+
+import typing
+from typing import Sequence
+
+import torch
+
+from .models import ModelConfig
+
+if typing.TYPE_CHECKING:
+    from ..cayley_graph_def import CayleyGraphDef
+
+
+class GroupTokenizer:
+    """Converts states to sequences of tokens, one token per group of consecutive elements of a state.
+
+    States of puzzles are usually encoded as permutations of sticker ids, where stickers of one piece occupy
+    consecutive positions. Such state can be described more compactly by one token per piece: the token says which
+    piece is in this slot and how it is oriented. For example, the Megaminx state has 120 elements: 20 corners with
+    3 stickers each, followed by 30 edges with 2 stickers each. It is described by 50 tokens (one per piece), and each
+    token takes one of 60 values (20 corners times 3 orientations, or 30 edges times 2 orientations). Such tokenization
+    is described by groups ``[[3, 20], [2, 30]]``, see :attr:`cayleypy.models.ModelConfig.tokenizer_groups`.
+
+    The i-th token is the value of the first element of the i-th group, counted from the beginning of the segment this
+    group belongs to (a segment is all groups described by one ``[group_size, num_groups]`` pair). Therefore token ids
+    of one segment are in range ``[0, group_size * num_groups)``, and token ids of different segments overlap. Models
+    can tell segments apart by position, or by adding an embedding of `token_type_ids` to the embedding of tokens.
+
+    This encodes the state without loss of information as long as elements of one group are always stickers of one
+    piece, listed in the same cyclic order - then the whole group is determined by its first element. Use
+    :meth:`verify` to check this for a particular graph.
+
+    Example:
+      >>> from cayleypy.models import GroupTokenizer
+      >>> tokenizer = GroupTokenizer([[3, 20], [2, 30]])  # Megaminx.
+      >>> tokenizer.n_tokens, tokenizer.vocab_size
+      (50, 60)
+    """
+
+    def __init__(self, groups: Sequence[Sequence[int]]):
+        """Creates tokenizer for states grouped as described by `groups`.
+
+        :param groups: Specification of groups, as a list of ``[group_size, num_groups]`` pairs. Groups are laid out in
+            the state consecutively, in the order they are listed here.
+        """
+        if len(groups) == 0:
+            raise ValueError("Groups must not be empty.")
+        parsed: list[list[int]] = []
+        for spec in groups:
+            if len(spec) != 2:
+                raise ValueError(f"Group must be described by pair [group_size, num_groups], got {list(spec)}.")
+            group_size, num_groups = int(spec[0]), int(spec[1])
+            if group_size < 1 or num_groups < 1:
+                raise ValueError(f"Group size and number of groups must be positive, got {[group_size, num_groups]}.")
+            parsed.append([group_size, num_groups])
+
+        self.groups: list[list[int]] = parsed
+        """Groups this tokenizer was created with, as a list of ``[group_size, num_groups]`` pairs."""
+
+        self.state_size: int = sum(group_size * num_groups for group_size, num_groups in parsed)
+        """Number of elements in the state this tokenizer expects."""
+
+        self.n_tokens: int = sum(num_groups for _, num_groups in parsed)
+        """Number of tokens one state is converted to."""
+
+        self.n_token_types: int = len(parsed)
+        """Number of segments (i.e. of ``[group_size, num_groups]`` pairs describing this tokenization)."""
+
+        self.vocab_size: int = max(group_size * num_groups for group_size, num_groups in parsed)
+        """Number of distinct values a token can take (i.e. size of vocabulary needed to embed tokens)."""
+
+        first_elements: list[int] = []
+        value_offsets: list[int] = []
+        token_types: list[int] = []
+        position = 0
+        for token_type, (group_size, num_groups) in enumerate(parsed):
+            segment_start = position
+            for _ in range(num_groups):
+                first_elements.append(position)
+                value_offsets.append(segment_start)
+                token_types.append(token_type)
+                position += group_size
+        self._first_elements = torch.tensor(first_elements, dtype=torch.int64)
+        self._value_offsets = torch.tensor(value_offsets, dtype=torch.int64)
+
+        self.token_type_ids: torch.Tensor = torch.tensor(token_types, dtype=torch.int64)
+        """Index of the segment each token belongs to, of shape ``[n_tokens]``."""
+
+    @staticmethod
+    def from_config(config: ModelConfig) -> "GroupTokenizer":
+        """Creates tokenizer described by `tokenizer_groups` field of the given model config.
+
+        :param config: Config of a model that consumes tokens.
+        :return: Tokenizer described by this config.
+        """
+        if config.tokenizer_groups is None:
+            raise ValueError(
+                f'Config of model of type "{config.model_type}" has no tokenizer_groups, but this model needs '
+                "tokenized states. Set tokenizer_groups to a list of [group_size, num_groups] pairs."
+            )
+        tokenizer = GroupTokenizer(config.tokenizer_groups)
+        if tokenizer.state_size != config.input_size:
+            raise ValueError(
+                f"Groups {tokenizer.groups} describe states with {tokenizer.state_size} elements, but input_size in "
+                f"the config is {config.input_size}."
+            )
+        return tokenizer
+
+    def __call__(self, states: torch.Tensor) -> torch.Tensor:
+        """Converts states to tokens.
+
+        :param states: States in "decoded" format, of shape ``[n_states, state_size]`` or ``[state_size]``.
+        :return: Tokens (int64), of shape ``[n_states, n_tokens]`` or ``[n_tokens]`` respectively.
+        """
+        if states.dim() == 0:
+            raise ValueError("States must have at least one dimension.")
+        if states.shape[-1] != self.state_size:
+            raise ValueError(
+                f"Groups {self.groups} describe states with {self.state_size} elements, got states with "
+                f"{states.shape[-1]} elements."
+            )
+        return states[..., self._first_elements.to(states.device)].to(torch.int64) - self._value_offsets.to(
+            states.device
+        )
+
+    def verify(self, graph_def: "CayleyGraphDef") -> None:
+        """Checks that states of the given graph are tokenized without loss of information.
+
+        This holds when the central state lists stickers of every piece in one group, and every generator moves
+        stickers of one piece to positions of one piece, preserving their cyclic order. Then every state reachable from
+        the central state has one piece per group, so the group is determined by its first element (i.e. by its token).
+
+        :param graph_def: Definition of the graph whose states are going to be tokenized.
+        :raises ValueError: If states of this graph cannot be tokenized this way.
+        """
+        if not graph_def.is_permutation_group():
+            raise ValueError("Tokenization is supported only for graphs with permutation generators.")
+        if graph_def.state_size != self.state_size:
+            raise ValueError(
+                f"Groups {self.groups} describe states with {self.state_size} elements, but states of this graph have "
+                f"{graph_def.state_size} elements."
+            )
+        self._verify_pieces([int(x) for x in graph_def.central_state], "central state")
+        for name, permutation in zip(graph_def.generator_names, graph_def.generators_permutations):
+            self._verify_pieces([int(x) for x in permutation], f'generator "{name}"')
+
+    def _verify_pieces(self, values: list[int], what: str) -> None:
+        """Checks that `values` list elements of one piece in every group, in cyclic order."""
+        position = 0
+        for group_size, num_groups in self.groups:
+            segment_start = position
+            segment_end = position + group_size * num_groups
+            for _ in range(num_groups):
+                group = values[position : position + group_size]
+                first = group[0]
+                if not segment_start <= first < segment_end:
+                    raise ValueError(
+                        f"In {what}, element at position {position} is {first}, which is outside of range "
+                        f"[{segment_start}, {segment_end}) of its segment (pieces of different kinds must not mix)."
+                    )
+                base = segment_start + (first - segment_start) // group_size * group_size
+                rotation = (first - segment_start) % group_size
+                expected = [base + (j + rotation) % group_size for j in range(group_size)]
+                if group != expected:
+                    raise ValueError(
+                        f"In {what}, elements at positions {position}..{position + group_size - 1} are {group}, but "
+                        f"expected {expected}: elements of one group must be elements of one piece, in cyclic order."
+                    )
+                position += group_size

--- a/cayleypy/models/tokenizer_test.py
+++ b/cayleypy/models/tokenizer_test.py
@@ -1,0 +1,161 @@
+import pytest
+import torch
+
+from .models import ModelConfig
+from .tokenizer import GroupTokenizer
+from ..cayley_graph_def import CayleyGraphDef
+from ..graphs_lib import MatrixGroups, PermutationGroups
+from ..puzzles import Puzzles
+
+# Megaminx: 20 corners with 3 stickers each, then 30 edges with 2 stickers each.
+MEGAMINX_GROUPS = [[3, 20], [2, 30]]
+
+
+def test_tokenizes_known_layout():
+    # Two pieces with 2 stickers each (positions 0..3), then three pieces with 1 sticker each (positions 4..6).
+    tokenizer = GroupTokenizer([[2, 2], [1, 3]])
+    assert tokenizer.state_size == 7
+    assert tokenizer.n_tokens == 5
+    assert tokenizer.n_token_types == 2
+    assert tokenizer.vocab_size == 4  # Segment of 2-sticker pieces has 4 possible tokens, segment of 1-sticker - 3.
+    assert torch.equal(tokenizer.token_type_ids, torch.tensor([0, 0, 1, 1, 1]))
+
+    # Solved state: first piece is in the first slot, and so on. Token of a slot is the value of its first element,
+    # counted from the beginning of the segment (so the second segment's tokens are 4,5,6 minus offset 4).
+    assert torch.equal(tokenizer(torch.tensor([0, 1, 2, 3, 4, 5, 6])), torch.tensor([0, 2, 0, 1, 2]))
+
+    # Pieces swapped: second piece is in the first slot and rotated, first piece is in the second slot.
+    assert torch.equal(tokenizer(torch.tensor([3, 2, 0, 1, 6, 4, 5])), torch.tensor([3, 0, 2, 0, 1]))
+
+
+def test_megaminx_sizes():
+    tokenizer = GroupTokenizer(MEGAMINX_GROUPS)
+    assert tokenizer.groups == MEGAMINX_GROUPS
+    assert tokenizer.state_size == 120
+    assert tokenizer.n_tokens == 50  # 20 corners + 30 edges.
+    assert tokenizer.vocab_size == 60  # 20 corners * 3 orientations = 30 edges * 2 orientations.
+    assert tokenizer.token_type_ids.tolist() == [0] * 20 + [1] * 30
+
+    graph_def = Puzzles.megaminx()
+    tokens = tokenizer(torch.tensor(graph_def.central_state))
+    # In the central state, i-th slot holds i-th piece in the default orientation.
+    assert torch.equal(tokens, torch.tensor([3 * i for i in range(20)] + [2 * i for i in range(30)]))
+
+
+def test_tokenizes_batch_of_states():
+    graph_def = Puzzles.megaminx()
+    tokenizer = GroupTokenizer(MEGAMINX_GROUPS)
+    states = torch.tensor([_apply(graph_def, i) for i in range(graph_def.n_generators)])
+    tokens = tokenizer(states)
+    assert tokens.shape == (graph_def.n_generators, 50)
+    assert tokens.dtype == torch.int64
+    for i in range(graph_def.n_generators):
+        assert torch.equal(tokens[i], tokenizer(states[i]))
+
+
+def test_tokens_identify_states():
+    # Tokenization is lossless for Megaminx: distinct states have distinct tokens.
+    graph_def = Puzzles.megaminx()
+    tokenizer = GroupTokenizer(MEGAMINX_GROUPS)
+    states = torch.tensor(_walk(graph_def, 40))
+    tokens = tokenizer(states)
+    assert len(torch.unique(tokens, dim=0)) == len(torch.unique(states, dim=0))
+
+
+def test_verify_accepts_puzzles_with_matching_grouping():
+    GroupTokenizer(MEGAMINX_GROUPS).verify(Puzzles.megaminx())
+    # Mini pyramorphix: 8 pieces with 3 stickers each.
+    GroupTokenizer([[3, 8]]).verify(Puzzles.mini_pyramorphix())
+
+
+def test_from_config():
+    config = ModelConfig(
+        model_type="MLP",
+        input_size=120,
+        num_classes_for_one_hot=120,
+        layers_sizes=[64],
+        tokenizer_groups=MEGAMINX_GROUPS,
+    )
+    tokenizer = GroupTokenizer.from_config(config)
+    assert tokenizer.groups == MEGAMINX_GROUPS
+    assert tokenizer.n_tokens == 50
+
+
+def test_rejects_states_of_wrong_size():
+    tokenizer = GroupTokenizer(MEGAMINX_GROUPS)
+    with pytest.raises(ValueError, match="120 elements, got states with 119 elements"):
+        tokenizer(torch.zeros((2, 119), dtype=torch.int64))
+    with pytest.raises(ValueError, match="at least one dimension"):
+        tokenizer(torch.tensor(0))
+
+
+def test_rejects_inconsistent_groups():
+    with pytest.raises(ValueError, match="must not be empty"):
+        GroupTokenizer([])
+    with pytest.raises(ValueError, match=r"pair \[group_size, num_groups\]"):
+        GroupTokenizer([[3, 20, 1]])
+    with pytest.raises(ValueError, match="must be positive"):
+        GroupTokenizer([[3, 0]])
+    with pytest.raises(ValueError, match="must be positive"):
+        GroupTokenizer([[-3, 20]])
+
+
+def test_from_config_rejects_config_without_tokenizer_groups():
+    config = ModelConfig(model_type="MLP", input_size=120, num_classes_for_one_hot=120, layers_sizes=[64])
+    with pytest.raises(ValueError, match="has no tokenizer_groups"):
+        GroupTokenizer.from_config(config)
+
+
+def test_from_config_rejects_groups_inconsistent_with_input_size():
+    config = ModelConfig(
+        model_type="MLP",
+        input_size=100,
+        num_classes_for_one_hot=120,
+        layers_sizes=[64],
+        tokenizer_groups=MEGAMINX_GROUPS,
+    )
+    with pytest.raises(ValueError, match="120 elements, but input_size in the config is 100"):
+        GroupTokenizer.from_config(config)
+
+
+def test_verify_rejects_wrong_grouping():
+    # In this encoding of the 2x2x2 cube, stickers of one corner are not in consecutive positions.
+    with pytest.raises(ValueError, match="elements of one piece, in cyclic order"):
+        GroupTokenizer([[3, 8]]).verify(Puzzles.rubik_cube(2, "QTM"))
+
+    # This generator swaps a piece of the first kind with a piece of the second kind.
+    mixing_kinds = CayleyGraphDef.create([[2, 3, 0, 1]], central_state=[0, 1, 2, 3])
+    with pytest.raises(ValueError, match="outside of range"):
+        GroupTokenizer([[2, 1], [2, 1]]).verify(mixing_kinds)
+
+    # Generators of LRX shift elements one by one, so they do not keep pairs of elements together.
+    with pytest.raises(ValueError, match='generator "L".* elements of one piece, in cyclic order'):
+        GroupTokenizer([[2, 3]]).verify(PermutationGroups.lrx(6))
+
+    # Elements of this central state are colors, not ids of stickers of pieces.
+    with pytest.raises(ValueError, match="central state.* elements of one piece, in cyclic order"):
+        GroupTokenizer([[2, 2]]).verify(PermutationGroups.lrx(4).with_central_state("0011"))
+
+
+def test_verify_rejects_incompatible_graphs():
+    with pytest.raises(ValueError, match="states of this graph have 120 elements"):
+        GroupTokenizer([[3, 8]]).verify(Puzzles.megaminx())
+    with pytest.raises(ValueError, match="permutation generators"):
+        GroupTokenizer([[3, 3]]).verify(MatrixGroups.heisenberg())
+
+
+def _apply(graph_def: CayleyGraphDef, generator_id: int, state=None) -> list[int]:
+    """Applies generator with the given id to the given state (central state by default)."""
+    if state is None:
+        state = list(graph_def.central_state)
+    return [state[i] for i in graph_def.generators_permutations[generator_id]]
+
+
+def _walk(graph_def: CayleyGraphDef, num_steps: int) -> list[list[int]]:
+    """Applies generators to the central state one by one, returning all visited states."""
+    state = list(graph_def.central_state)
+    states = [state]
+    for step in range(num_steps):
+        state = _apply(graph_def, (step * 7) % graph_def.n_generators, state)
+        states.append(state)
+    return states

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -43,6 +43,7 @@ Beam search and ML
     cayleypy.algo.BeamSearchResult
     cayleypy.algo.RandomWalksGenerator
     cayleypy.models.ModelConfig
+    cayleypy.models.GroupTokenizer
     cayleypy.models.graph_hash
     cayleypy.models.save_checkpoint
     cayleypy.models.load_checkpoint


### PR DESCRIPTION
Adds `GroupTokenizer` — the input layer for sequence models (Q-transformer, next PR).

Puzzle states are usually permutations of sticker ids, where stickers of one piece occupy consecutive positions. `GroupTokenizer` converts such a state into one token per piece, as described by the `tokenizer_groups` field of `ModelConfig` (added in the parent PR). For Megaminx (groups `[[3, 20], [2, 30]]`) a state of 120 elements becomes 50 tokens with a vocabulary of 60 — 20 corners × 3 orientations = 30 edges × 2 orientations.

Semantics: the i-th token is the value of the first element of the i-th group, counted from the beginning of the segment this group belongs to (a segment = all groups described by one `[group_size, num_groups]` pair). So a token says both which piece is in this slot and how it is oriented. Token ids of different segments overlap; `token_type_ids` lets a model tell segments apart with an extra embedding.

This encoding is lossless exactly when every group always holds stickers of one piece in the same cyclic order. `verify(graph_def)` checks this for a graph: it validates the central state and every generator, which by induction covers every reachable state. It accepts Megaminx with `[[3, 20], [2, 30]]` and Mini Pyramorphix with `[[3, 8]]`, and rejects e.g. the 2×2×2 cube with `[[3, 8]]` (its stickers of one corner are not consecutive).

Also: `from_config(config)` builds the tokenizer from a `ModelConfig` and checks `tokenizer_groups` against `input_size`.

Tests (`cayleypy/models/tokenizer_test.py`, 12 new): hand-built layout with expected tokens; Megaminx sizes and tokens of the central state; batch vs single state; losslessness (distinct states → distinct tokens); `verify` on two real puzzles; `from_config`. Errors: state of wrong size, 0-dim input, empty/malformed/non-positive groups, config without `tokenizer_groups`, groups inconsistent with `input_size`, `verify` rejecting wrong grouping (wrong cyclic order, pieces of different kinds mixed, colors instead of sticker ids), non-permutation graph and state size mismatch.

`./lint.sh` clean, `black --check .` clean, docs build with `-W` clean, `RUN_SLOW_TESTS=1 pytest` = 335 passed / 12 skipped / 3 xfailed on Python 3.12 (torch 2.13) and 3.9 (torch 2.8).

Draft: base is the `feat/score-children-contract` branch (parent PR #1); will be retargeted once that is merged.


---

Based on #191, which is the base branch of this PR, so this diff is only its own change. #191 should be merged first.
