### PR TITLE
Add trainer for models estimating distances in a Cayley graph

### DIFF
--- a/cayleypy/__init__.py
+++ b/cayleypy/__init__.py
@@ -8,4 +8,4 @@ from .graphs_lib import prepare_graph, PermutationGroups, MatrixGroups
 from .models import ModelConfig, load_checkpoint, save_checkpoint
 from .predictor import Predictor
 from .puzzles import Puzzles, GapPuzzles
-from .train import Loss, MseLoss, PinballLoss, make_loss
+from .train import Loss, MseLoss, PinballLoss, make_loss, TrainConfig, Trainer, TrainResult

--- a/cayleypy/train/__init__.py
+++ b/cayleypy/train/__init__.py
@@ -1,1 +1,3 @@
+from .config import TrainConfig
 from .losses import Loss, MseLoss, PinballLoss, make_loss
+from .trainer import Trainer, TrainResult

--- a/cayleypy/train/config.py
+++ b/cayleypy/train/config.py
@@ -1,0 +1,86 @@
+"""Configuration of the training process."""
+
+from dataclasses import dataclass
+from typing import Optional
+
+from .losses import Loss, make_loss
+
+# Modes of random walk generation that can be used to produce training data, see
+# :class:`cayleypy.algo.RandomWalksGenerator`.
+RANDOM_WALK_MODES = ("classic", "bfs", "nbt")
+
+
+def _check_positive(name: str, value: float) -> None:
+    if value <= 0:
+        raise ValueError(f"{name} must be positive, got {value}.")
+
+
+@dataclass(frozen=True)
+class TrainConfig:
+    """Configuration of the process of training a model to estimate distances in a Cayley graph.
+
+    Training is split into epochs. On every epoch, a fresh set of random walks is generated and the model makes one
+    pass over it in batches of `batch_size` states. Because data is regenerated, the model almost never sees the same
+    state twice, so there is no separate notion of a dataset.
+
+    Defaults are chosen to train a small model on a small graph in seconds. Serious training needs longer walks, more
+    of them, and more epochs.
+
+    :param n_epochs: Number of epochs (how many times to generate data and pass over it).
+    :param n_walks: Number of random walks generated on every epoch (`width` of the walks).
+    :param rw_length: Length of every random walk. Must be at least 2. Should be at least as large as the diameter of
+        the graph, otherwise the model never sees distant states.
+    :param rw_mode: Mode of random walk generation - one of "classic", "bfs", "nbt". Defaults to "nbt", which mixes
+        fastest, meaning the number of steps is the closest estimate of the true distance.
+    :param nbt_history_depth: For "nbt" mode, how many previous levels to remember and ban from revisiting.
+    :param batch_size: Number of states in one training batch.
+    :param lr: Initial learning rate.
+    :param lr_min: Learning rate at the end of training. The learning rate follows a cosine schedule from `lr` to
+        `lr_min` over `n_epochs` epochs.
+    :param weight_decay: Weight decay of the AdamW optimizer. 0 (the default) makes it behave as plain Adam.
+    :param ema_decay: Decay of the exponential moving average of weights, which is usually a better predictor than the
+        weights themselves. 0 disables averaging.
+    :param loss: Name of the loss - see :func:`cayleypy.train.make_loss`.
+    :param tau: Quantile for the pinball loss (ignored by other losses).
+    :param seed: Random seed. If set, training is deterministic on a given device.
+    :param verbose: Level of logging. 0 means no logging, 1 means one line per epoch.
+    """
+
+    n_epochs: int = 100
+    n_walks: int = 128
+    rw_length: int = 20
+    rw_mode: str = "nbt"
+    nbt_history_depth: int = 1
+    batch_size: int = 512
+    lr: float = 1e-3
+    lr_min: float = 0.0
+    weight_decay: float = 0.0
+    ema_decay: float = 0.99
+    loss: str = "mse"
+    tau: float = 0.5
+    seed: Optional[int] = None
+    verbose: int = 0
+
+    def __post_init__(self):
+        _check_positive("n_epochs", self.n_epochs)
+        _check_positive("n_walks", self.n_walks)
+        _check_positive("batch_size", self.batch_size)
+        _check_positive("lr", self.lr)
+        if self.rw_length < 2:
+            raise ValueError(f"rw_length must be at least 2, got {self.rw_length}.")
+        if self.rw_mode not in RANDOM_WALK_MODES:
+            raise ValueError(f'Unknown rw_mode: "{self.rw_mode}". Supported modes are: {RANDOM_WALK_MODES}.')
+        if self.nbt_history_depth < 0:
+            raise ValueError(f"nbt_history_depth must be non-negative, got {self.nbt_history_depth}.")
+        if not 0.0 <= self.lr_min <= self.lr:
+            raise ValueError(f"lr_min must be between 0 and lr={self.lr}, got {self.lr_min}.")
+        if self.weight_decay < 0:
+            raise ValueError(f"weight_decay must be non-negative, got {self.weight_decay}.")
+        if not 0.0 <= self.ema_decay < 1.0:
+            raise ValueError(f"ema_decay must be at least 0 and less than 1, got {self.ema_decay}.")
+        # Creates the loss to fail early (rather than after the first epoch of data generation) if it is misconfigured.
+        self.make_loss()
+
+    def make_loss(self) -> Loss:
+        """Creates the loss described by this config."""
+        return make_loss(self.loss, self.tau)

--- a/cayleypy/train/config.py
+++ b/cayleypy/train/config.py
@@ -32,7 +32,8 @@ class TrainConfig:
         the graph, otherwise the model never sees distant states.
     :param rw_mode: Mode of random walk generation - one of "classic", "bfs", "nbt". Defaults to "nbt", which mixes
         fastest, meaning the number of steps is the closest estimate of the true distance.
-    :param nbt_history_depth: For "nbt" mode, how many previous levels to remember and ban from revisiting.
+    :param nbt_history_depth: For "nbt" mode, how many previous levels to remember and ban from revisiting. Must be at
+        least 1 in that mode, because a walk that bans nothing never counts a step.
     :param batch_size: Number of states in one training batch.
     :param lr: Initial learning rate.
     :param lr_min: Learning rate at the end of training. The learning rate follows a cosine schedule from `lr` to
@@ -72,6 +73,13 @@ class TrainConfig:
             raise ValueError(f'Unknown rw_mode: "{self.rw_mode}". Supported modes are: {RANDOM_WALK_MODES}.')
         if self.nbt_history_depth < 0:
             raise ValueError(f"nbt_history_depth must be non-negative, got {self.nbt_history_depth}.")
+        if self.rw_mode == "nbt" and self.nbt_history_depth == 0:
+            # The step counter of a non-backtracking walk only advances when the walk moves to a state that is not
+            # banned, so with nothing banned it never advances and every generated state gets target distance 0.
+            raise ValueError(
+                'nbt_history_depth must be at least 1 in "nbt" mode, got 0. A walk that remembers no previous levels '
+                "never counts a step, so every state it generates would be labelled with distance 0."
+            )
         if not 0.0 <= self.lr_min <= self.lr:
             raise ValueError(f"lr_min must be between 0 and lr={self.lr}, got {self.lr_min}.")
         if self.weight_decay < 0:

--- a/cayleypy/train/trainer.py
+++ b/cayleypy/train/trainer.py
@@ -3,6 +3,7 @@
 import copy
 import math
 import typing
+import warnings
 from dataclasses import dataclass
 from typing import Optional
 
@@ -53,6 +54,20 @@ def _validate_model_config(model_config: ModelConfig, graph: "CayleyGraph") -> N
             )
 
 
+def _warn_if_not_inverse_closed(graph: "CayleyGraph") -> None:
+    """Warns that targets generated for this graph need not measure the distance a predictor is asked about."""
+    if graph.definition.generators_inverse_closed:
+        return
+    warnings.warn(
+        "Generators of this graph are not inverse closed, so the random walks used for training measure the distance "
+        "from the central state, which need not be the distance to it - and a predictor is asked for the latter. To "
+        "get targets in the direction a predictor is asked about, train on CayleyGraph.with_inverted_generators. This "
+        "check looks at the generators alone, so it is a false alarm for a graph whose induced action on states is "
+        "symmetric anyway.",
+        stacklevel=3,
+    )
+
+
 class Trainer:
     """Trains a model to estimate distance from the central state of a Cayley graph.
 
@@ -65,6 +80,10 @@ class Trainer:
     :meth:`predictor` and :meth:`save` use by default.
 
     Training progress is reported with `print` when `TrainConfig.verbose` is at least 1.
+
+    Walks start at the central state, so what their targets measure is the distance from it, while a predictor is asked
+    for the distance to it. These are the same distance when the generators of the graph are inverse closed, and the
+    trainer warns when they are not.
 
     Example:
 
@@ -97,6 +116,7 @@ class Trainer:
             `model_config`.
         """
         _validate_model_config(model_config, graph)
+        _warn_if_not_inverse_closed(graph)
         self.graph = graph
         self.model_config = model_config
         self.config = config if config is not None else TrainConfig()

--- a/cayleypy/train/trainer.py
+++ b/cayleypy/train/trainer.py
@@ -1,0 +1,272 @@
+"""Trainer for models estimating distances in a Cayley graph."""
+
+import copy
+import math
+import typing
+from dataclasses import dataclass
+from typing import Optional
+
+import torch
+from torch import nn
+
+from .config import TrainConfig
+from ..models.checkpoint import PathType, load_checkpoint, save_checkpoint
+from ..models.models import ModelConfig
+from ..predictor import Predictor
+
+if typing.TYPE_CHECKING:
+    from ..cayley_graph import CayleyGraph
+
+
+@dataclass
+class TrainResult:
+    """Result of training.
+
+    :param losses: Mean loss on every epoch. Because data is regenerated on every epoch, these are losses on states
+        the model has not seen before, so they can be read as a validation curve.
+    :param n_steps: Total number of optimizer steps made.
+    """
+
+    losses: list[float]
+    n_steps: int
+
+
+def _validate_model_config(model_config: ModelConfig, graph: "CayleyGraph") -> None:
+    """Checks that a model described by this config can be trained for this graph."""
+    state_size = graph.definition.state_size
+    if model_config.input_size != state_size:
+        raise ValueError(
+            f"Model expects states of size {model_config.input_size}, but states of this graph have size {state_size}."
+        )
+    if model_config.n_outputs != 1:
+        raise ValueError(
+            f"Trainer supports only models with a single output, got n_outputs={model_config.n_outputs}. A model with "
+            "one output per generator needs a target for every output, which random walks do not provide."
+        )
+    # Models consuming tokenized states do not use one-hot encoding, so this only applies to the other ones.
+    if model_config.tokenizer_groups is None:
+        max_value = int(graph.central_state.max())
+        if model_config.num_classes_for_one_hot <= max_value:
+            raise ValueError(
+                f"Model one-hot encodes states with {model_config.num_classes_for_one_hot} classes, which is not "
+                f"enough for this graph, where an element of a state can be as large as {max_value}."
+            )
+
+
+class Trainer:
+    """Trains a model to estimate distance from the central state of a Cayley graph.
+
+    On every epoch, a fresh set of random walks is generated, and the number of steps at which a state was visited is
+    used as its target distance. These targets are upper estimates of the true distance (see
+    :class:`cayleypy.algo.RandomWalksGenerator`), which is why fast-mixing walks ("nbt") are the default.
+
+    The model is fitted with AdamW, the learning rate follows a cosine schedule, and an exponential moving average
+    (EMA) of the weights is maintained - it is usually a better predictor than the weights themselves, and it is what
+    :meth:`predictor` and :meth:`save` use by default.
+
+    Training progress is reported with `print` when `TrainConfig.verbose` is at least 1.
+
+    Example:
+
+    >>> from cayleypy import CayleyGraph, PermutationGroups
+    >>> from cayleypy.models import ModelConfig
+    >>> from cayleypy.train import TrainConfig, Trainer
+    >>> graph = CayleyGraph(PermutationGroups.lrx(4), device="cpu")
+    >>> model_config = ModelConfig(model_type="MLP", input_size=4, num_classes_for_one_hot=4, layers_sizes=[16])
+    >>> train_config = TrainConfig(n_epochs=2, n_walks=8, rw_length=4, batch_size=16, seed=0)
+    >>> result = Trainer(graph, model_config, train_config).train()
+    >>> len(result.losses)
+    2
+    """
+
+    def __init__(
+        self,
+        graph: "CayleyGraph",
+        model_config: ModelConfig,
+        config: Optional[TrainConfig] = None,
+        model: Optional[nn.Module] = None,
+    ):
+        """Initializes Trainer.
+
+        :param graph: Graph for which to train the model.
+        :param model_config: Config describing the model to train. It is also stored in checkpoints written by
+            :meth:`save`, which makes them self-describing.
+        :param config: Configuration of the training process. Defaults to `TrainConfig()`.
+        :param model: Model to train (optional). Defaults to a model built from `model_config` with randomly
+            initialized weights. Pass a model to continue training an existing one - it must be described by
+            `model_config`.
+        """
+        _validate_model_config(model_config, graph)
+        self.graph = graph
+        self.model_config = model_config
+        self.config = config if config is not None else TrainConfig()
+        if self.config.seed is not None:
+            torch.manual_seed(self.config.seed)
+        self.model = (model_config.build_model() if model is None else model).to(graph.device)
+        self.loss = self.config.make_loss()
+        self.optimizer = torch.optim.AdamW(
+            self.model.parameters(), lr=self.config.lr, weight_decay=self.config.weight_decay
+        )
+        self.scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
+            self.optimizer, T_max=self.config.n_epochs, eta_min=self.config.lr_min
+        )
+        self.ema_model: Optional[nn.Module] = None
+        if self.config.ema_decay > 0:
+            self.ema_model = copy.deepcopy(self.model).eval()
+            for parameter in self.ema_model.parameters():
+                parameter.requires_grad_(False)
+        self.epoch = 0
+        self.n_steps = 0
+
+    @staticmethod
+    def from_checkpoint(
+        path: PathType,
+        graph: "CayleyGraph",
+        config: Optional[TrainConfig] = None,
+    ) -> "Trainer":
+        """Creates trainer continuing training of a model stored in a checkpoint.
+
+        Only weights are stored in checkpoints, so the optimizer, the learning rate schedule and the EMA copy start
+        anew (the EMA copy starts from the weights that were loaded).
+
+        :param path: Path to a checkpoint written by :func:`cayleypy.models.save_checkpoint` (e.g. by :meth:`save`).
+        :param graph: Graph for which to continue training. If the checkpoint says which graph the model was trained
+            for, it must be this graph.
+        :param config: Configuration of the training process. Defaults to `TrainConfig()`.
+        :return: The trainer.
+        """
+        model, model_config = load_checkpoint(path, device=str(graph.device), graph_def=graph.definition)
+        return Trainer(graph, model_config, config=config, model=model)
+
+    @property
+    def learning_rate(self) -> float:
+        """Learning rate that will be used on the next optimizer step."""
+        return float(self.optimizer.param_groups[0]["lr"])
+
+    def generate_data(self) -> tuple[torch.Tensor, torch.Tensor]:
+        """Generates training data for one epoch - random walks with estimated distances.
+
+        :return: Pair of tensors (states, targets), where ``targets[i]`` is the estimated distance from the central
+            state to ``states[i]``.
+        """
+        states, distances = self.graph.random_walks(
+            width=self.config.n_walks,
+            length=self.config.rw_length,
+            mode=self.config.rw_mode,
+            nbt_history_depth=self.config.nbt_history_depth,
+        )
+        return states, distances.to(torch.float32)
+
+    def train_step(
+        self,
+        states: torch.Tensor,
+        targets: torch.Tensor,
+        mask: Optional[torch.Tensor] = None,
+        weights: Optional[torch.Tensor] = None,
+    ) -> float:
+        """Makes one optimizer step on the given batch, then updates the EMA copy of the weights.
+
+        :param states: States (in decoded representation) to train on.
+        :param targets: Target distances for `states`.
+        :param mask: Which targets are known (optional), see :class:`cayleypy.train.Loss`.
+        :param weights: Importance of every target (optional), see :class:`cayleypy.train.Loss`.
+        :return: Value of the loss on this batch, before the step.
+        """
+        self.model.train()
+        self.optimizer.zero_grad(set_to_none=True)
+        loss = self.loss(self.model(states), targets, mask=mask, weights=weights)
+        loss.backward()
+        self.optimizer.step()
+        self.n_steps += 1
+        self._update_ema()
+        return float(loss.detach())
+
+    def train_on_data(self, states: torch.Tensor, targets: torch.Tensor) -> float:
+        """Makes one pass over the given states, in batches of `TrainConfig.batch_size`.
+
+        :param states: States (in decoded representation) to train on.
+        :param targets: Target distances for `states`.
+        :return: Mean loss over the batches of this pass.
+        """
+        n_states = int(states.shape[0])
+        if n_states == 0:
+            raise ValueError("Cannot train on an empty set of states.")
+        n_batches = int(math.ceil(n_states / self.config.batch_size))
+        permutation = torch.randperm(n_states, device=states.device)
+        losses = [self.train_step(states[idx], targets[idx]) for idx in permutation.tensor_split(n_batches)]
+        return sum(losses) / len(losses)
+
+    def train_epoch(self) -> float:
+        """Generates data for one epoch and makes one pass over it.
+
+        :return: Mean loss on this epoch.
+        """
+        learning_rate = self.learning_rate
+        states, targets = self.generate_data()
+        mean_loss = self.train_on_data(states, targets)
+        self.scheduler.step()
+        self.epoch += 1
+        if self.config.verbose >= 1:
+            print(f"Epoch {self.epoch}: loss={mean_loss:.5f}, lr={learning_rate:.3e}.")
+        return mean_loss
+
+    def train(self) -> TrainResult:
+        """Trains the model for `TrainConfig.n_epochs` epochs.
+
+        Calling this again continues training the same model, but the cosine schedule of the learning rate is built for
+        one call, so on the second call the learning rate goes back up.
+
+        :return: Result of training, with the loss curve.
+        """
+        losses = [self.train_epoch() for _ in range(self.config.n_epochs)]
+        if self.config.verbose >= 1:
+            print(f"Training finished in {self.n_steps} steps, loss on the last epoch: {losses[-1]:.5f}.")
+        return TrainResult(losses=losses, n_steps=self.n_steps)
+
+    def predictor(self, use_ema: bool = True) -> Predictor:
+        """Creates predictor using the trained model, e.g. to pass it to beam search.
+
+        :param use_ema: Whether to use the EMA copy of the weights (if it is maintained) rather than the weights
+            themselves. Defaults to True.
+        :return: The predictor.
+        """
+        return Predictor(self.graph, self.model_for_inference(use_ema))
+
+    def save(self, path: PathType, use_ema: bool = True) -> ModelConfig:
+        """Saves the trained model as a self-describing checkpoint.
+
+        The checkpoint also remembers which graph the model was trained for, so loading it for another graph fails
+        instead of silently producing nonsense.
+
+        :param path: Path to the file to write.
+        :param use_ema: Whether to save the EMA copy of the weights (if it is maintained) rather than the weights
+            themselves. Defaults to True.
+        :return: Config stored in the checkpoint (it is `model_config` with the hash of the graph filled in).
+        """
+        return save_checkpoint(path, self.model_for_inference(use_ema), self.model_config, self.graph.definition)
+
+    def model_for_inference(self, use_ema: bool = True) -> nn.Module:
+        """Returns the model to use for prediction - either the EMA copy of the weights, or the weights themselves.
+
+        :param use_ema: Whether to prefer the EMA copy. If it is not maintained (`TrainConfig.ema_decay` is 0), the
+            trained model is returned regardless.
+        :return: The model.
+        """
+        if use_ema and self.ema_model is not None:
+            return self.ema_model
+        return self.model
+
+    def _update_ema(self) -> None:
+        """Moves the EMA copy of the weights towards the current weights."""
+        if self.ema_model is None:
+            return
+        decay = self.config.ema_decay
+        ema_state = self.ema_model.state_dict()
+        with torch.no_grad():
+            for key, value in self.model.state_dict().items():
+                ema_value = ema_state[key]
+                if ema_value.is_floating_point():
+                    ema_value.mul_(decay).add_(value.detach(), alpha=1.0 - decay)
+                else:
+                    # Integer entries (e.g. counters of batch normalization) have no meaningful average.
+                    ema_value.copy_(value)

--- a/cayleypy/train/trainer_test.py
+++ b/cayleypy/train/trainer_test.py
@@ -1,0 +1,282 @@
+import os
+
+import pytest
+import torch
+
+from .config import TrainConfig
+from .trainer import Trainer
+from ..cayley_graph import CayleyGraph
+from ..graphs_lib import PermutationGroups
+from ..models.checkpoint import graph_hash, load_checkpoint
+from ..models.models import ModelConfig
+from ..predictor import Predictor
+
+RUN_SLOW_TESTS = os.getenv("RUN_SLOW_TESTS") == "1"
+
+MLP_CONFIG = ModelConfig(model_type="MLP", input_size=5, num_classes_for_one_hot=5, layers_sizes=[16, 16])
+
+# Configuration making training as short as possible - for tests that check mechanics rather than model quality.
+TINY_CONFIG = TrainConfig(n_epochs=2, n_walks=4, rw_length=3, batch_size=8, seed=0)
+
+
+def _lrx5() -> CayleyGraph:
+    return CayleyGraph(PermutationGroups.lrx(5), device="cpu")
+
+
+def _weights(model) -> list[torch.Tensor]:
+    return [parameter.detach().clone() for parameter in model.parameters()]
+
+
+def _all_states_with_distances(graph: CayleyGraph) -> tuple[torch.Tensor, torch.Tensor]:
+    """Returns all states of the graph with their true distances, computed by exact BFS."""
+    layers = graph.bfs(max_layer_size_to_store=None).layers
+    states = torch.vstack([torch.as_tensor(layer) for layer in layers.values()])
+    distances = torch.hstack([torch.full((len(layer),), distance) for distance, layer in layers.items()])
+    return states, distances
+
+
+def test_train_returns_loss_for_every_epoch():
+    trainer = Trainer(_lrx5(), MLP_CONFIG, TINY_CONFIG)
+    result = trainer.train()
+    assert len(result.losses) == 2
+    assert all(loss > 0 for loss in result.losses)
+    # 4 walks of length 3 give 12 states, which is 2 batches of 8, so there are 2 optimizer steps per epoch.
+    assert result.n_steps == 4
+    assert trainer.n_steps == 4
+    assert trainer.epoch == 2
+
+
+def test_generate_data():
+    config = TrainConfig(n_walks=8, rw_length=4, rw_mode="classic")
+    graph = _lrx5()
+    states, targets = Trainer(graph, MLP_CONFIG, config).generate_data()
+    assert states.shape == (32, 5)
+    assert targets.shape == (32,)
+    assert targets.dtype == torch.float32
+    # First `n_walks` states are copies of the central state, and their distance is 0.
+    assert torch.equal(states[:8], graph.central_state.expand(8, 5))
+    assert torch.equal(targets[:8], torch.zeros(8))
+    assert torch.all(targets >= 0)
+
+
+def test_training_is_deterministic_with_seed():
+    config = TrainConfig(n_epochs=3, n_walks=8, rw_length=4, batch_size=16, seed=42)
+    losses1 = Trainer(_lrx5(), MLP_CONFIG, config).train().losses
+    losses2 = Trainer(_lrx5(), MLP_CONFIG, config).train().losses
+    assert losses1 == losses2
+
+
+def test_train_step_reduces_loss_on_the_same_batch():
+    trainer = Trainer(_lrx5(), MLP_CONFIG, TrainConfig(lr=0.01, seed=0))
+    states, targets = trainer.generate_data()
+    first_loss = trainer.train_step(states, targets)
+    for _ in range(10):
+        last_loss = trainer.train_step(states, targets)
+    assert last_loss < first_loss
+
+
+def test_fully_masked_batch_does_not_change_weights():
+    trainer = Trainer(_lrx5(), MLP_CONFIG, TrainConfig(seed=0))
+    states, targets = trainer.generate_data()
+    weights_before = _weights(trainer.model)
+    loss = trainer.train_step(states, targets, mask=torch.zeros_like(targets))
+    assert loss == 0
+    for before, after in zip(weights_before, _weights(trainer.model)):
+        assert torch.equal(before, after)
+
+
+def test_ema_follows_weights():
+    decay = 0.9
+    trainer = Trainer(_lrx5(), MLP_CONFIG, TrainConfig(ema_decay=decay, lr=0.01, seed=0))
+    assert trainer.ema_model is not None
+    states, targets = trainer.generate_data()
+
+    ema_before = _weights(trainer.ema_model)
+    for _ in range(2):
+        trainer.train_step(states, targets)
+        model_weights = _weights(trainer.model)
+        ema_after = _weights(trainer.ema_model)
+        for before, model_weight, after in zip(ema_before, model_weights, ema_after):
+            assert torch.allclose(after, decay * before + (1 - decay) * model_weight)
+        ema_before = ema_after
+
+    # The average lags behind the weights, so they are not the same.
+    assert not torch.equal(_weights(trainer.ema_model)[0], _weights(trainer.model)[0])
+
+
+def test_ema_can_be_disabled():
+    trainer = Trainer(_lrx5(), MLP_CONFIG, TrainConfig(ema_decay=0, n_epochs=1, n_walks=4, rw_length=3))
+    assert trainer.ema_model is None
+    trainer.train()
+    # Even when the average is requested, there is nothing to return except the trained model itself.
+    assert trainer.model_for_inference(use_ema=True) is trainer.model
+
+
+def test_learning_rate_follows_cosine_schedule():
+    config = TrainConfig(n_epochs=4, n_walks=4, rw_length=3, batch_size=8, lr=0.01, lr_min=0.001)
+    trainer = Trainer(_lrx5(), MLP_CONFIG, config)
+    learning_rates = []
+    for _ in range(config.n_epochs):
+        learning_rates.append(trainer.learning_rate)
+        trainer.train_epoch()
+    assert learning_rates[0] == pytest.approx(config.lr)
+    assert learning_rates == sorted(learning_rates, reverse=True)
+    assert trainer.learning_rate == pytest.approx(config.lr_min)
+
+
+def test_predictor_uses_averaged_weights():
+    trainer = Trainer(_lrx5(), MLP_CONFIG, TINY_CONFIG)
+    trainer.train()
+    states, _ = trainer.generate_data()
+    predictor = trainer.predictor()
+    assert isinstance(predictor, Predictor)
+    assert predictor(states).shape == (states.shape[0],)
+    with torch.no_grad():
+        assert torch.equal(predictor(states), trainer.ema_model(states))
+        assert torch.equal(trainer.predictor(use_ema=False)(states), trainer.model(states))
+
+
+def test_save_and_resume_from_checkpoint(tmp_path):
+    path = tmp_path / "model.pt"
+    graph = _lrx5()
+    trainer = Trainer(graph, MLP_CONFIG, TINY_CONFIG)
+    trainer.train()
+    saved_config = trainer.save(path)
+    assert saved_config.graph_hash == graph_hash(graph.definition)
+
+    resumed = Trainer.from_checkpoint(path, graph, TINY_CONFIG)
+    assert resumed.model_config == saved_config
+    states, _ = trainer.generate_data()
+    with torch.no_grad():
+        # Resumed trainer starts from exactly the weights that were saved.
+        assert torch.equal(resumed.model(states), trainer.ema_model(states))
+    # Training continues from these weights.
+    resumed.train()
+    assert resumed.n_steps == trainer.n_steps
+    with torch.no_grad():
+        assert not torch.equal(resumed.model(states), trainer.ema_model(states))
+
+
+def test_save_can_store_weights_instead_of_their_average(tmp_path):
+    path = tmp_path / "model.pt"
+    trainer = Trainer(_lrx5(), MLP_CONFIG, TINY_CONFIG)
+    trainer.train()
+    trainer.save(path, use_ema=False)
+    loaded_model, _ = load_checkpoint(path)
+    states, _ = trainer.generate_data()
+    with torch.no_grad():
+        assert torch.equal(loaded_model(states), trainer.model(states))
+
+
+def test_verbose_prints_progress(capsys):
+    Trainer(_lrx5(), MLP_CONFIG, TrainConfig(n_epochs=2, n_walks=4, rw_length=3, verbose=1)).train()
+    output = capsys.readouterr().out
+    assert "Epoch 1: loss=" in output
+    assert "Epoch 2: loss=" in output
+    assert "Training finished in 2 steps" in output
+
+    Trainer(_lrx5(), MLP_CONFIG, TrainConfig(n_epochs=2, n_walks=4, rw_length=3, verbose=0)).train()
+    assert capsys.readouterr().out == ""
+
+
+def test_train_config_rejects_invalid_values():
+    with pytest.raises(ValueError, match="n_epochs must be positive"):
+        TrainConfig(n_epochs=0)
+    with pytest.raises(ValueError, match="n_walks must be positive"):
+        TrainConfig(n_walks=-1)
+    with pytest.raises(ValueError, match="batch_size must be positive"):
+        TrainConfig(batch_size=0)
+    with pytest.raises(ValueError, match="lr must be positive"):
+        TrainConfig(lr=0)
+    with pytest.raises(ValueError, match="rw_length must be at least 2"):
+        TrainConfig(rw_length=1)
+    with pytest.raises(ValueError, match="Unknown rw_mode"):
+        TrainConfig(rw_mode="random")
+    with pytest.raises(ValueError, match="nbt_history_depth must be non-negative"):
+        TrainConfig(nbt_history_depth=-1)
+    with pytest.raises(ValueError, match="lr_min must be between 0 and lr"):
+        TrainConfig(lr=0.001, lr_min=0.01)
+    with pytest.raises(ValueError, match="weight_decay must be non-negative"):
+        TrainConfig(weight_decay=-0.1)
+    with pytest.raises(ValueError, match="ema_decay must be at least 0 and less than 1"):
+        TrainConfig(ema_decay=1.0)
+    with pytest.raises(ValueError, match="Unknown loss"):
+        TrainConfig(loss="hinge")
+    with pytest.raises(ValueError, match="tau must be strictly between 0 and 1"):
+        TrainConfig(loss="pinball", tau=0)
+
+
+def test_trainer_rejects_model_for_states_of_another_size():
+    config = ModelConfig(model_type="MLP", input_size=6, num_classes_for_one_hot=6, layers_sizes=[16])
+    with pytest.raises(ValueError, match="Model expects states of size 6, but states of this graph have size 5"):
+        Trainer(_lrx5(), config, TINY_CONFIG)
+
+
+def test_trainer_rejects_multi_output_model():
+    config = ModelConfig(model_type="MLP", input_size=5, num_classes_for_one_hot=5, layers_sizes=[16], n_outputs=3)
+    with pytest.raises(ValueError, match="Trainer supports only models with a single output"):
+        Trainer(_lrx5(), config, TINY_CONFIG)
+
+
+def test_trainer_rejects_model_with_too_few_classes():
+    config = ModelConfig(model_type="MLP", input_size=5, num_classes_for_one_hot=3, layers_sizes=[16])
+    with pytest.raises(ValueError, match="which is not enough for this graph"):
+        Trainer(_lrx5(), config, TINY_CONFIG)
+
+
+def test_train_on_data_rejects_empty_data():
+    trainer = Trainer(_lrx5(), MLP_CONFIG, TINY_CONFIG)
+    with pytest.raises(ValueError, match="Cannot train on an empty set of states"):
+        trainer.train_on_data(torch.zeros((0, 5), dtype=torch.int64), torch.zeros((0,)))
+
+
+def test_from_checkpoint_rejects_checkpoint_for_another_graph(tmp_path):
+    path = tmp_path / "model.pt"
+    Trainer(_lrx5(), MLP_CONFIG, TINY_CONFIG).save(path)
+    another_graph = CayleyGraph(PermutationGroups.lrx(5, k=2), device="cpu")
+    with pytest.raises(ValueError, match="was trained for another graph"):
+        Trainer.from_checkpoint(path, another_graph, TINY_CONFIG)
+
+
+# To run slow tests like this, do `RUN_SLOW_TESTS=1 pytest`
+@pytest.mark.skipif(not RUN_SLOW_TESTS, reason="slow test")
+def test_learns_true_distances_from_exact_labels():
+    # In "bfs" mode on a graph this small, walks visit the whole graph, so targets are the true distances and the loss
+    # can go all the way to 0. Targets estimated from random walks are upper bounds, so with them the loss plateaus at
+    # the noise in the labels instead (see the test below, which trains that way).
+    graph = _lrx5()
+    config = TrainConfig(rw_mode="bfs", n_epochs=200, n_walks=64, rw_length=12, batch_size=32, lr=5e-3, seed=42)
+    trainer = Trainer(graph, ModelConfig("MLP", 5, 5, [64, 64]), config)
+    result = trainer.train()
+    assert result.losses[-1] < 0.2 * result.losses[0]
+
+    states, distances = _all_states_with_distances(graph)
+    predictor = trainer.predictor()
+    assert float((predictor(states) - distances).abs().mean()) < 0.5
+
+    # Such a model is an almost perfect heuristic: beam search finds an optimal path for every state of the graph even
+    # with beam width 1, while with the default (Hamming distance) heuristic it solves 10 states out of 120.
+    for i in range(states.shape[0]):
+        result = graph.beam_search(start_state=states[i], predictor=predictor, beam_width=1, return_path=True)
+        assert result.path_found, f"No path found for {states[i].tolist()}."
+        assert result.path_length == int(distances[i])
+        assert torch.equal(graph.apply_path(states[i], result.path).reshape((-1,)), graph.central_state)
+
+
+@pytest.mark.skipif(not RUN_SLOW_TESTS, reason="slow test")
+def test_model_trained_on_random_walks_solves_all_states():
+    graph = _lrx5()
+    config = TrainConfig(n_epochs=150, n_walks=64, rw_length=12, batch_size=64, lr=5e-3, seed=42)
+    trainer = Trainer(graph, ModelConfig("MLP", 5, 5, [64, 64]), config)
+    result = trainer.train()
+    assert result.losses[-1] < 0.5 * result.losses[0]
+
+    # Distances estimated from non-backtracking random walks are overestimated, so this model does not predict true
+    # distances. It is still good enough for beam search to solve every state of the graph with a narrow beam, where
+    # the default (Hamming distance) heuristic solves 23 states out of 120.
+    states, _ = _all_states_with_distances(graph)
+    predictor = trainer.predictor()
+    for i in range(states.shape[0]):
+        result = graph.beam_search(start_state=states[i], predictor=predictor, beam_width=5, return_path=True)
+        assert result.path_found, f"No path found for {states[i].tolist()}."
+        assert torch.equal(graph.apply_path(states[i], result.path).reshape((-1,)), graph.central_state)

--- a/cayleypy/train/trainer_test.py
+++ b/cayleypy/train/trainer_test.py
@@ -194,6 +194,8 @@ def test_train_config_rejects_invalid_values():
         TrainConfig(rw_mode="random")
     with pytest.raises(ValueError, match="nbt_history_depth must be non-negative"):
         TrainConfig(nbt_history_depth=-1)
+    with pytest.raises(ValueError, match='nbt_history_depth must be at least 1 in "nbt" mode'):
+        TrainConfig(rw_mode="nbt", nbt_history_depth=0)
     with pytest.raises(ValueError, match="lr_min must be between 0 and lr"):
         TrainConfig(lr=0.001, lr_min=0.01)
     with pytest.raises(ValueError, match="weight_decay must be non-negative"):

--- a/cayleypy/train/trainer_test.py
+++ b/cayleypy/train/trainer_test.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 
 import pytest
 import torch
@@ -6,6 +7,7 @@ import torch
 from .config import TrainConfig
 from .trainer import Trainer
 from ..cayley_graph import CayleyGraph
+from ..cayley_graph_def import CayleyGraphDef
 from ..graphs_lib import PermutationGroups
 from ..models.checkpoint import graph_hash, load_checkpoint
 from ..models.models import ModelConfig
@@ -224,6 +226,21 @@ def test_trainer_rejects_model_with_too_few_classes():
     config = ModelConfig(model_type="MLP", input_size=5, num_classes_for_one_hot=3, layers_sizes=[16])
     with pytest.raises(ValueError, match="which is not enough for this graph"):
         Trainer(_lrx5(), config, TINY_CONFIG)
+
+
+def test_trainer_warns_when_generators_are_not_inverse_closed():
+    # Directed 5-cycle - the inverse of its only generator is not a generator, so reaching the central state from the
+    # state one step away from it takes 4 steps, not 1.
+    graph = CayleyGraph(CayleyGraphDef.create([[1, 2, 3, 4, 0]]), device="cpu")
+    with pytest.warns(UserWarning, match="not inverse closed"):
+        Trainer(graph, MLP_CONFIG, TINY_CONFIG)
+
+
+def test_trainer_does_not_warn_about_direction_for_inverse_closed_generators():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        Trainer(_lrx5(), MLP_CONFIG, TINY_CONFIG)
+    assert not any("inverse closed" in str(warning.message) for warning in caught)
 
 
 def test_train_on_data_rejects_empty_data():

--- a/cayleypy/train/trainer_test.py
+++ b/cayleypy/train/trainer_test.py
@@ -280,3 +280,34 @@ def test_model_trained_on_random_walks_solves_all_states():
         result = graph.beam_search(start_state=states[i], predictor=predictor, beam_width=5, return_path=True)
         assert result.path_found, f"No path found for {states[i].tolist()}."
         assert torch.equal(graph.apply_path(states[i], result.path).reshape((-1,)), graph.central_state)
+
+
+class _ModelWithIntegerBuffer(torch.nn.Module):
+    """Model whose state dict has a non-float entry, as batch normalization has (its counter of batches)."""
+
+    n_batches: torch.Tensor
+
+    def __init__(self):
+        super().__init__()
+        self.layer = torch.nn.Linear(5, 1)
+        self.register_buffer("n_batches", torch.zeros(1, dtype=torch.int64))
+
+    def forward(self, states: torch.Tensor) -> torch.Tensor:
+        self.n_batches += 1
+        return self.layer(states.to(torch.float32)).squeeze(-1)
+
+
+def test_ema_copies_non_float_entries_of_the_state_dict():
+    """Test that entries with no meaningful average (e.g. counters of batch normalization) are copied, not averaged."""
+    config = TrainConfig(ema_decay=0.9, lr=0.01, n_walks=4, rw_length=3, batch_size=8, seed=0)
+    model = _ModelWithIntegerBuffer()
+    trainer = Trainer(_lrx5(), MLP_CONFIG, config, model=model)
+    assert trainer.ema_model is not None
+    states, targets = trainer.generate_data()
+
+    trainer.train_step(states, targets)
+    trainer.train_step(states, targets)
+
+    # Averaging an integer entry in place would fail outright, and its value must follow the model exactly.
+    assert int(model.n_batches) == 2
+    assert int(trainer.ema_model.state_dict()["n_batches"]) == 2

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -58,6 +58,9 @@ Training
     cayleypy.train.MseLoss
     cayleypy.train.PinballLoss
     cayleypy.train.make_loss
+    cayleypy.train.TrainConfig
+    cayleypy.train.Trainer
+    cayleypy.train.TrainResult
 
 BFS algorithm and its variations
 ''''''''''''''''''''''''''''''''


### PR DESCRIPTION
Adds `cayleypy/train/config.py` and `cayleypy/train/trainer.py`: the core of a trainer for models that estimate distance from the central state.

## What it does

`TrainConfig` (frozen dataclass) describes the whole process: how much data to generate (`n_walks`, `rw_length`, `rw_mode`, `nbt_history_depth`), the optimizer (`lr`, `lr_min`, `weight_decay`), weight averaging (`ema_decay`), the loss (`loss`, `tau`), plus `seed` and `verbose`. All values are validated on construction, so a misconfigured run fails immediately rather than after an epoch of data generation.

`Trainer` runs it:

- **data** — on every epoch a fresh set of random walks is generated with `RandomWalksGenerator` (default mode is `nbt`, which mixes fastest, so the number of steps is the closest estimate of the true distance). Because data is regenerated, the loss per epoch reads as a validation curve.
- **optimization** — AdamW + `CosineAnnealingLR` from `lr` to `lr_min` over `n_epochs`.
- **weight averaging** — an EMA copy of the weights is maintained and is what `predictor()` and `save()` use by default. It is also the frozen target copy that Bellman/DAVI fine-tuning will need later.
- **checkpoints** — `save()` writes a self-describing checkpoint (config + weights + hash of the graph), `Trainer.from_checkpoint()` continues training from one. Loading a checkpoint for another graph fails instead of silently producing nonsense.
- **progress** — `print` when `TrainConfig.verbose >= 1`, no progress-bar dependency.

`train_step(states, targets, mask=..., weights=...)` is public, so the data sources and the Bellman mode that come next can feed their own batches (including sparsely labeled ones) into the same loop.

Scope of this PR is deliberately the core loop only: single-output models trained on random walks. BFS anchors, sparse-Q labels and beam-search paths are the next PR; a Q-model (`n_outputs != 1`) is rejected with a clear message until then, because random walks do not provide a target for every output.

## Tests

20 new tests in `cayleypy/train/trainer_test.py`. Fast ones cover mechanics: number of optimizer steps and losses returned, shape/dtype/values of generated data, determinism under a seed, one step reducing the loss on a fixed batch, a fully masked batch leaving the weights untouched, the EMA relation checked against `decay*ema + (1-decay)*w` on two consecutive steps, EMA disabled, the cosine schedule ending at `lr_min`, `predictor()`/`save()` using averaged weights (and both opting out), checkpoint round trip and resume, `verbose` output, and the error cases (every invalid config field, model for states of another size, multi-output model, too few one-hot classes, empty data, checkpoint for another graph).

Two slow tests (`RUN_SLOW_TESTS=1`) on `lrx(5)`, seeded:

- with exact labels (`rw_mode="bfs"` visits the whole graph on such a small graph) the final loss is under 0.2 of the initial one, mean absolute error against exact BFS is under 0.5, and beam search with the trained model finds an **optimal** path for all 120 states with **beam width 1** — where the default Hamming heuristic solves 10.
- trained on non-backtracking random walks, the model solves **all 120 states with beam width 5** — where the Hamming heuristic solves 23. These targets are overestimates, so the loss plateaus at the label noise (about 0.4 of the initial loss) and the model does not predict true distances; it is still a much better beam-search heuristic.

## Relation to upstream cayleypy/cayleypy#151

[cayleypy/cayleypy#151](https://github.com/cayleypy/cayleypy/pull/151) by @vlzm proposed a trainer (in `cayleypy/trainers/`) and has been approved but unmerged since October 2025; the pipeline here is the same idea, and credit for it goes to that work. Differences:

- built on the `score_children` contract and `ModelConfig`/checkpoint format from the contract PR, so trained models are usable by beam search and reloadable without knowing the architecture;
- losses come from the separate losses PR, including masked-sparse, which is what makes the upcoming sparse-Q labels possible;
- EMA of the weights;
- zero new dependencies (#151 added some to `pyproject.toml`) — progress is a `verbose` flag and `print`, as in `beam_search.py`;
- lives in `cayleypy/train/`, so it does not conflict with `cayleypy/trainers/` from #151.

## Stacking

This PR depends on both the contract PR (checkpoints) and the losses PR, which are not merged yet. `base/trainer-core` is a mechanical merge of those two branches, used as the base so that the diff here shows only the trainer. Draft until they land.

## Checks

`./lint.sh` clean (black 68 files, pylint 10.00/10, mypy 68 files), `black --check .` clean over the whole repo, `docs/build_docs.sh` (`-W`) clean, doctests pass. `RUN_SLOW_TESTS=1 pytest`: 366 passed / 12 skipped / 3 xfailed on Python 3.12 (torch 2.13) and on Python 3.9 (torch 2.8).


---

Based on `base/trainer-core`, a mechanical merge of #191 and #192 with no changes of its own. Both should be merged first.
