### PR TITLE
Add EnsemblePredictor combining several predictors with weighted sum

### DIFF
--- a/cayleypy/__init__.py
+++ b/cayleypy/__init__.py
@@ -4,6 +4,7 @@ from .cayley_graph_def import CayleyGraphDef, MatrixGenerator
 from .cayley_path import CayleyPath
 from .create_graph import create_graph
 from .datasets import load_dataset
+from .ensemble import EnsemblePredictor
 from .graphs_lib import prepare_graph, PermutationGroups, MatrixGroups
 from .models import ModelConfig, load_checkpoint, save_checkpoint
 from .predictor import Predictor

--- a/cayleypy/ensemble.py
+++ b/cayleypy/ensemble.py
@@ -43,6 +43,7 @@ class EnsemblePredictor(Predictor):
         :param members: Predictors to combine. They must be for the same graph, which is checked by comparing the
             mathematical definitions of their graphs (see :func:`cayleypy.models.graph_hash`) - members for different
             graphs would have their scores of unrelated children summed up.
+            All members must have the same number of outputs, which becomes `n_outputs` of the ensemble.
         :param weights: Weight of each member (optional). Score of member ``i`` is multiplied by ``weights[i]``, and
             the products are summed up, without any normalization. If None, defaults to ``1/len(members)`` for every
             member, which makes the ensemble compute the average of its members.
@@ -79,9 +80,19 @@ class EnsemblePredictor(Predictor):
                     "different)."
                 )
 
+        n_outputs = members[0].n_outputs
+        for i, member in enumerate(members):
+            if member.n_outputs != n_outputs:
+                raise ValueError(
+                    f"All members of an ensemble must have the same number of outputs, but member 0 has {n_outputs} "
+                    f"and member {i} has {member.n_outputs}."
+                )
+
         self.members = list(members)
         self.weights = [float(w) for w in weights]
         super().__init__(members[0].graph, self._predict_ensemble)
+        # An ensemble of Q-models is a Q-model: callers dispatch on this to score children instead of states.
+        self.n_outputs = n_outputs
 
     def _predict_ensemble(self, states: torch.Tensor) -> torch.Tensor:
         ans = self.weights[0] * self.members[0](states)

--- a/cayleypy/ensemble.py
+++ b/cayleypy/ensemble.py
@@ -29,6 +29,7 @@ class EnsemblePredictor(Predictor):
 
     Example:
 
+    >>> import torch
     >>> from cayleypy import CayleyGraph, EnsemblePredictor, PermutationGroups, Predictor
     >>> graph = CayleyGraph(PermutationGroups.lrx(5), device="cpu")
     >>> ensemble = EnsemblePredictor([Predictor(graph, "hamming"), Predictor(graph, "zero")], [0.75, 0.25])

--- a/cayleypy/ensemble.py
+++ b/cayleypy/ensemble.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 import torch
 
+from .models.checkpoint import graph_hash
 from .predictor import Predictor
 
 
@@ -18,10 +19,13 @@ class EnsemblePredictor(Predictor):
     sum. Weights are used as they are given and are not normalized, so it is up to the caller to make them sum to 1
     (which is what the default weights do).
 
-    Members can be any predictors, including multi-output (Q-) models. Both scoring methods are ensembled:
-    :meth:`__call__` combines scores of the states themselves, and :meth:`score_children` combines scores of their
-    children (asking every member for its own children scores, so members implementing the fast single-pass
-    :meth:`Predictor.score_children` keep using it).
+    Both scoring methods are ensembled: :meth:`__call__` combines scores of the states themselves, and
+    :meth:`score_children` combines scores of their children (asking every member for its own children scores, so
+    members implementing the fast single-pass :meth:`Predictor.score_children` keep using it).
+
+    Members scoring children of a state instead of the state itself (Q-models) can be ensembled through
+    :meth:`score_children` only - like the models themselves, they have nothing to say about a state, so
+    :meth:`__call__` needs every member to return one score per state.
 
     Example:
 
@@ -35,8 +39,9 @@ class EnsemblePredictor(Predictor):
     def __init__(self, members: list[Predictor], weights: Optional[list[float]] = None):
         """Initializes EnsemblePredictor.
 
-        :param members: Predictors to combine. They must be for the same graph (at least, the number of generators and
-            the state size must be the same).
+        :param members: Predictors to combine. They must be for the same graph, which is checked by comparing the
+            mathematical definitions of their graphs (see :func:`cayleypy.models.graph_hash`) - members for different
+            graphs would have their scores of unrelated children summed up.
         :param weights: Weight of each member (optional). Score of member ``i`` is multiplied by ``weights[i]``, and
             the products are summed up, without any normalization. If None, defaults to ``1/len(members)`` for every
             member, which makes the ensemble compute the average of its members.
@@ -55,6 +60,7 @@ class EnsemblePredictor(Predictor):
             raise ValueError(f"Ensemble has {len(members)} members, but {len(weights)} weights were given.")
 
         first = members[0].graph.definition
+        first_hash = graph_hash(first)
         for i, member in enumerate(members):
             other = member.graph.definition
             if other.n_generators != first.n_generators or other.state_size != first.state_size:
@@ -62,6 +68,14 @@ class EnsemblePredictor(Predictor):
                     "All members of an ensemble must be for the same graph, but member 0 has "
                     f"{first.n_generators} generators and state size {first.state_size}, while member {i} has "
                     f"{other.n_generators} generators and state size {other.state_size}."
+                )
+            # Graphs of the same shape can still be different graphs, and for members scoring children even a different
+            # order of the generators is enough to make the weighted sum meaningless.
+            if graph_hash(other) != first_hash:
+                raise ValueError(
+                    f"All members of an ensemble must be for the same graph, but member {i} is for another graph with "
+                    "the same number of generators and the same state size (its generators or its central state are "
+                    "different)."
                 )
 
         self.members = list(members)

--- a/cayleypy/ensemble.py
+++ b/cayleypy/ensemble.py
@@ -1,0 +1,86 @@
+"""Ensembles of predictors."""
+
+from typing import Optional
+
+import torch
+
+from .predictor import Predictor
+
+
+class EnsemblePredictor(Predictor):
+    """Predictor computing weighted sum of scores of several other predictors.
+
+    Predictors trained independently make different errors, so their combination estimates distances better than any
+    of them alone. In beam search, ensembling two predictors gives improvement comparable to doubling the beam width,
+    while being cheaper in memory.
+
+    This ensemble is flat: its members are ordinary predictors, and their scores are combined by a single weighted
+    sum. Weights are used as they are given and are not normalized, so it is up to the caller to make them sum to 1
+    (which is what the default weights do).
+
+    Members can be any predictors, including multi-output (Q-) models. Both scoring methods are ensembled:
+    :meth:`__call__` combines scores of the states themselves, and :meth:`score_children` combines scores of their
+    children (asking every member for its own children scores, so members implementing the fast single-pass
+    :meth:`Predictor.score_children` keep using it).
+
+    Example:
+
+    >>> from cayleypy import CayleyGraph, EnsemblePredictor, PermutationGroups, Predictor
+    >>> graph = CayleyGraph(PermutationGroups.lrx(5), device="cpu")
+    >>> ensemble = EnsemblePredictor([Predictor(graph, "hamming"), Predictor(graph, "zero")], [0.75, 0.25])
+    >>> ensemble(torch.tensor([[1, 0, 2, 3, 4]]))
+    tensor([1.5000])
+    """
+
+    def __init__(self, members: list[Predictor], weights: Optional[list[float]] = None):
+        """Initializes EnsemblePredictor.
+
+        :param members: Predictors to combine. They must be for the same graph (at least, the number of generators and
+            the state size must be the same).
+        :param weights: Weight of each member (optional). Score of member ``i`` is multiplied by ``weights[i]``, and
+            the products are summed up, without any normalization. If None, defaults to ``1/len(members)`` for every
+            member, which makes the ensemble compute the average of its members.
+        """
+        if len(members) == 0:
+            raise ValueError("Ensemble must have at least one member.")
+        for i, member in enumerate(members):
+            if not isinstance(member, Predictor):
+                raise TypeError(
+                    f"Member {i} of the ensemble has type {type(member).__name__}, but Predictor was expected. "
+                    "Models and heuristics must be wrapped in Predictor first."
+                )
+        if weights is None:
+            weights = [1.0 / len(members)] * len(members)
+        elif len(weights) != len(members):
+            raise ValueError(f"Ensemble has {len(members)} members, but {len(weights)} weights were given.")
+
+        first = members[0].graph.definition
+        for i, member in enumerate(members):
+            other = member.graph.definition
+            if other.n_generators != first.n_generators or other.state_size != first.state_size:
+                raise ValueError(
+                    "All members of an ensemble must be for the same graph, but member 0 has "
+                    f"{first.n_generators} generators and state size {first.state_size}, while member {i} has "
+                    f"{other.n_generators} generators and state size {other.state_size}."
+                )
+
+        self.members = list(members)
+        self.weights = [float(w) for w in weights]
+        super().__init__(members[0].graph, self._predict_ensemble)
+
+    def _predict_ensemble(self, states: torch.Tensor) -> torch.Tensor:
+        ans = self.weights[0] * self.members[0](states)
+        for weight, member in zip(self.weights[1:], self.members[1:]):
+            ans = ans + weight * member(states)
+        return ans
+
+    def score_children(self, states: torch.Tensor) -> torch.Tensor:
+        """Estimates distances to children of given states as weighted sum of estimates of the members.
+
+        :param states: States (in decoded representation) whose children to score.
+        :return: Tensor of shape ``[n_states, n_generators]`` with estimated distances for children.
+        """
+        ans = self.weights[0] * self.members[0].score_children(states)
+        for weight, member in zip(self.weights[1:], self.members[1:]):
+            ans = ans + weight * member.score_children(states)
+        return ans

--- a/cayleypy/ensemble_test.py
+++ b/cayleypy/ensemble_test.py
@@ -177,3 +177,37 @@ def test_member_that_is_not_predictor_is_rejected():
     graph = CayleyGraph(PermutationGroups.lrx(5), device="cpu")
     with pytest.raises(TypeError, match="wrapped in Predictor"):
         EnsemblePredictor([Predictor(graph, "hamming"), "hamming"])  # type: ignore[list-item]
+
+
+class _QModel(torch.nn.Module):
+    """Model with one output per generator, whose scores depend on the state so that averaging is visible."""
+
+    def __init__(self, n_outputs: int, shift: float):
+        super().__init__()
+        self.n_outputs = n_outputs
+        self.shift = shift
+
+    def forward(self, states: torch.Tensor) -> torch.Tensor:
+        return states[:, :1].float() + torch.arange(self.n_outputs, dtype=torch.float32) + self.shift
+
+
+def test_ensemble_of_q_models_is_a_q_model():
+    """Test that an ensemble reports the outputs of its members, so callers score children rather than states."""
+    graph = CayleyGraph(PermutationGroups.lrx(5), device="cpu")
+    n_generators = graph.definition.n_generators
+    members = [Predictor(graph, _QModel(n_generators, 0.0)), Predictor(graph, _QModel(n_generators, 4.0))]
+
+    ensemble = EnsemblePredictor(members)
+
+    assert ensemble.n_outputs == n_generators
+    expected = (members[0].score_children(STATES) + members[1].score_children(STATES)) / 2
+    assert torch.allclose(ensemble.score_children(STATES), expected)
+
+
+def test_ensemble_rejects_members_with_different_number_of_outputs():
+    """Test that a Q-model and a single-output model are not ensembled (their scores are of different things)."""
+    graph = CayleyGraph(PermutationGroups.lrx(5), device="cpu")
+    members = [Predictor(graph, "hamming"), Predictor(graph, _QModel(graph.definition.n_generators, 0.0))]
+
+    with pytest.raises(ValueError, match="same number of outputs"):
+        EnsemblePredictor(members)

--- a/cayleypy/ensemble_test.py
+++ b/cayleypy/ensemble_test.py
@@ -1,0 +1,154 @@
+import pytest
+import torch
+
+from .cayley_graph import CayleyGraph
+from .cayley_graph_def import CayleyGraphDef
+from .ensemble import EnsemblePredictor
+from .graphs_lib import PermutationGroups
+from .predictor import Predictor
+
+# States used in most tests below. Distances from the central state of lrx(5) (i.e. [0,1,2,3,4]) are 0, 5, 4, 2.
+STATES = torch.tensor([[0, 1, 2, 3, 4], [1, 2, 3, 4, 0], [4, 3, 2, 1, 0], [0, 2, 1, 3, 4]])
+
+
+def _first_element(states: torch.Tensor) -> torch.Tensor:
+    """Heuristic returning the first element of the state (used as a second, unrelated member of ensembles)."""
+    return states[:, 0].to(torch.float32)
+
+
+class QLikePredictor(Predictor):
+    """Predictor scoring all children in one call, like Q-models do."""
+
+    def __init__(self, graph: CayleyGraph):
+        super().__init__(graph, "hamming")
+        self.score_children_calls = 0
+
+    def score_children(self, states: torch.Tensor) -> torch.Tensor:
+        self.score_children_calls += 1
+        n_generators = self.graph.definition.n_generators
+        return torch.full((states.shape[0], n_generators), 10.0)
+
+
+def test_ensemble_of_predictions():
+    graph = CayleyGraph(PermutationGroups.lrx(5), device="cpu")
+    ensemble = EnsemblePredictor([Predictor(graph, "hamming"), Predictor(graph, _first_element)], [0.75, 0.25])
+
+    # Hamming distances are [0,5,4,2], first elements are [0,1,4,0].
+    expected = torch.tensor([0.0, 0.75 * 5 + 0.25 * 1, 0.75 * 4 + 0.25 * 4, 0.75 * 2 + 0.25 * 0])
+    assert torch.allclose(ensemble(STATES), expected)
+
+
+def test_ensemble_of_children_scores():
+    graph = CayleyGraph(PermutationGroups.lrx(5), device="cpu")
+    n_generators = graph.definition.n_generators
+    member1, member2 = Predictor(graph, "hamming"), Predictor(graph, _first_element)
+    ensemble = EnsemblePredictor([member1, member2], [0.75, 0.25])
+
+    scores = ensemble.score_children(STATES)
+    assert scores.shape == (4, n_generators)
+    for i in range(n_generators):
+        # Column i must contain scores of children obtained by applying generator i.
+        children = graph.apply_path(STATES, [i])
+        assert torch.allclose(scores[:, i], 0.75 * member1(children) + 0.25 * member2(children))
+
+    # Sanity check that this test can distinguish columns from each other.
+    assert len({tuple(scores[:, i].tolist()) for i in range(n_generators)}) > 1
+
+
+def test_ensemble_of_one_member_equals_that_member():
+    graph = CayleyGraph(PermutationGroups.lrx(5), device="cpu")
+    member = Predictor(graph, "hamming")
+    ensemble = EnsemblePredictor([member], [1.0])
+    assert torch.allclose(ensemble(STATES), member(STATES).to(torch.float32))
+    assert torch.allclose(ensemble.score_children(STATES), member.score_children(STATES).to(torch.float32))
+
+
+def test_default_weights_average_members():
+    graph = CayleyGraph(PermutationGroups.lrx(5), device="cpu")
+    member1, member2 = Predictor(graph, "hamming"), Predictor(graph, _first_element)
+    ensemble = EnsemblePredictor([member1, member2])
+    assert ensemble.weights == [0.5, 0.5]
+    assert torch.allclose(ensemble(STATES), (member1(STATES) + member2(STATES)) / 2)
+
+
+def test_ensemble_uses_score_children_of_members():
+    graph = CayleyGraph(PermutationGroups.lrx(5), device="cpu")
+    fast_member = QLikePredictor(graph)
+    slow_member = Predictor(graph, "hamming")
+    ensemble = EnsemblePredictor([fast_member, slow_member], [1.0, 1.0])
+
+    scores = ensemble.score_children(STATES)
+    assert fast_member.score_children_calls == 1
+    assert torch.allclose(scores, 10.0 + slow_member.score_children(STATES).to(torch.float32))
+
+
+def test_ensemble_batches_predictions():
+    graph = CayleyGraph(PermutationGroups.lrx(5), device="cpu", batch_size=3)
+    member1, member2 = Predictor(graph, "hamming"), Predictor(graph, _first_element)
+    ensemble = EnsemblePredictor([member1, member2], [0.75, 0.25])
+
+    # There are 7 states and 21 children, so both of them are processed in several batches.
+    states = torch.tensor([[i % 5, (i + 1) % 5, 2, 3, 4] for i in range(7)])
+    assert torch.allclose(ensemble(states), 0.75 * member1(states) + 0.25 * member2(states))
+    scores = ensemble.score_children(states)
+    assert scores.shape == (7, graph.definition.n_generators)
+    for i in range(graph.definition.n_generators):
+        children = graph.apply_path(states, [i])
+        assert torch.allclose(scores[:, i], 0.75 * member1(children) + 0.25 * member2(children))
+
+
+def test_ensemble_works_in_beam_search():
+    graph = CayleyGraph(PermutationGroups.lrx(8), device="cpu")
+    ensemble = EnsemblePredictor([Predictor(graph, "hamming"), Predictor(graph, "zero")], [0.9, 0.1])
+    start_state = [7, 6, 5, 4, 3, 2, 1, 0]
+
+    result = graph.beam_search(
+        start_state=start_state, predictor=ensemble, beam_mode="simple", beam_width=10**7, return_path=True
+    )
+    assert result.path_found
+    assert result.path_length <= 28
+    assert torch.equal(graph.apply_path(start_state, result.path)[0], torch.tensor(graph.definition.central_state))
+
+
+def test_weights_are_not_normalized():
+    graph = CayleyGraph(PermutationGroups.lrx(5), device="cpu")
+    member1, member2 = Predictor(graph, "hamming"), Predictor(graph, _first_element)
+    ensemble = EnsemblePredictor([member1, member2], [2.0, 3.0])
+
+    expected = 2.0 * member1(STATES) + 3.0 * member2(STATES)
+    assert torch.allclose(ensemble(STATES), expected)
+    # Ranking is preserved, but the scale is not: weights summing to 5 are not silently divided by 5.
+    assert not torch.allclose(ensemble(STATES), expected / 5)
+
+
+def test_empty_ensemble_is_rejected():
+    with pytest.raises(ValueError, match="at least one member"):
+        EnsemblePredictor([])
+
+
+def test_wrong_number_of_weights_is_rejected():
+    graph = CayleyGraph(PermutationGroups.lrx(5), device="cpu")
+    members = [Predictor(graph, "hamming"), Predictor(graph, "zero")]
+    with pytest.raises(ValueError, match="2 members, but 3 weights"):
+        EnsemblePredictor(members, [0.5, 0.3, 0.2])
+
+
+def test_members_with_different_number_of_generators_are_rejected():
+    graph1 = CayleyGraph(PermutationGroups.lrx(5), device="cpu")
+    graph2 = CayleyGraph(CayleyGraphDef.create([[1, 2, 3, 4, 0]]), device="cpu")
+    assert graph1.definition.state_size == graph2.definition.state_size
+    with pytest.raises(ValueError, match="same graph"):
+        EnsemblePredictor([Predictor(graph1, "hamming"), Predictor(graph2, "hamming")])
+
+
+def test_members_with_different_state_size_are_rejected():
+    graph1 = CayleyGraph(PermutationGroups.lrx(5), device="cpu")
+    graph2 = CayleyGraph(PermutationGroups.lrx(6), device="cpu")
+    with pytest.raises(ValueError, match="same graph"):
+        EnsemblePredictor([Predictor(graph1, "hamming"), Predictor(graph2, "hamming")])
+
+
+def test_member_that_is_not_predictor_is_rejected():
+    graph = CayleyGraph(PermutationGroups.lrx(5), device="cpu")
+    with pytest.raises(TypeError, match="wrapped in Predictor"):
+        EnsemblePredictor([Predictor(graph, "hamming"), "hamming"])  # type: ignore[list-item]

--- a/cayleypy/ensemble_test.py
+++ b/cayleypy/ensemble_test.py
@@ -148,6 +148,31 @@ def test_members_with_different_state_size_are_rejected():
         EnsemblePredictor([Predictor(graph1, "hamming"), Predictor(graph2, "hamming")])
 
 
+def test_members_for_another_graph_of_the_same_shape_are_rejected():
+    graph1 = CayleyGraph(PermutationGroups.lrx(5), device="cpu")
+    # The same three generators in another order: the shape of the graph is the same, but scores of children are not
+    # comparable between the two graphs.
+    permutations = PermutationGroups.lrx(5).generators_permutations
+    graph2 = CayleyGraph(CayleyGraphDef.create([list(p) for p in reversed(permutations)]), device="cpu")
+    assert graph1.definition.n_generators == graph2.definition.n_generators
+    assert graph1.definition.state_size == graph2.definition.state_size
+    with pytest.raises(ValueError, match="same graph"):
+        EnsemblePredictor([Predictor(graph1, "hamming"), Predictor(graph2, "hamming")])
+
+
+def test_predictions_of_ensemble_of_q_models_are_rejected():
+    # A Q-model has nothing to say about a state itself, so such an ensemble works through score_children only.
+    graph = CayleyGraph(PermutationGroups.lrx(5), device="cpu")
+
+    class _QModel(torch.nn.Module):
+        def forward(self, states: torch.Tensor) -> torch.Tensor:
+            return torch.zeros((states.shape[0], graph.definition.n_generators))
+
+    ensemble = EnsemblePredictor([Predictor(graph, _QModel()), Predictor(graph, _QModel())])
+    with pytest.raises(ValueError, match="one score per state"):
+        ensemble(STATES)
+
+
 def test_member_that_is_not_predictor_is_rejected():
     graph = CayleyGraph(PermutationGroups.lrx(5), device="cpu")
     with pytest.raises(TypeError, match="wrapped in Predictor"):

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -39,6 +39,7 @@ Beam search and ML
     :toctree: generated/
 
     cayleypy.Predictor
+    cayleypy.EnsemblePredictor
     cayleypy.algo.BeamSearchAlgorithm
     cayleypy.algo.BeamSearchResult
     cayleypy.algo.RandomWalksGenerator


### PR DESCRIPTION
Adds `EnsemblePredictor` — a flat weighted-sum ensemble of predictors.

## Why

Predictors trained independently make different errors, so a weighted sum of their scores estimates distances better than any of them alone. Empirically, in beam search ensembling two predictors gives improvement comparable to doubling the beam width, while being much cheaper in memory.

## What

- `cayleypy/ensemble.py`: `EnsemblePredictor(members, weights)`. It is a `Predictor`, so it can be passed to `beam_search` as is.
  - Both scoring methods are ensembled: `__call__` (scores of the states themselves) and `score_children` (scores of their children). `score_children` asks every member for its own children scores, so members implementing the fast single-pass `score_children` (Q-models) keep using it instead of falling back to per-child evaluation.
  - Weights are used as given and are **not** normalized. By default every member gets weight `1/n`, so the ensemble computes the average of its members.
  - Validation: non-empty member list, matching number of weights, members being `Predictor`s for the same graph (same number of generators and state size).
- The ensemble is deliberately flat: no nested ensembles, no per-member configs — there is no use case for them yet.
- Exported from `cayleypy/__init__.py`, added to `docs/api.rst`.

## Tests

`cayleypy/ensemble_test.py` (13 tests): weighted sum of predictions against manually computed numbers (0.75/0.25); column-wise check of ensembled `score_children`; single-member ensemble equals its member; default weights average the members; delegation to a member's own `score_children` (asserting it is called exactly once); batching of both methods when states do not fit in one batch; ensemble used as predictor in beam search on `lrx(8)` (path found and verified). Error cases: empty ensemble, wrong number of weights, members with different number of generators, members with different state size, member that is not a `Predictor`; plus an explicit test that weights are not normalized.

## Validation

`./lint.sh` (black, pylint 10.00/10, mypy) and `black --check .` are green; `RUN_SLOW_TESTS=1 pytest` is 336 passed / 12 skipped / 3 xfailed on Python 3.12 (torch 2.13) and on Python 3.9 (torch 2.8); docs build with `-W` is green.

Depends on the `score_children` contract, so based on `feat/score-children-contract` (draft until that one is merged).


---

Based on #193, which adds `Predictor.n_outputs` — an ensemble of Q-models reports the outputs of its members, so it needs that attribute. #193 should be merged first.
