### PR TITLE
Add QV model with Q- and V-heads and v-consistency rescoring

### DIFF
--- a/cayleypy/models/__init__.py
+++ b/cayleypy/models/__init__.py
@@ -1,2 +1,3 @@
 from .checkpoint import graph_hash, load_checkpoint, save_checkpoint
 from .models import MlpModel, ModelConfig, ResMlpModel
+from .qv_model import QVModel

--- a/cayleypy/models/models.py
+++ b/cayleypy/models/models.py
@@ -8,17 +8,19 @@ import kagglehub
 import torch
 from torch import nn
 
+from .qv_model import QVModel
+
 
 @dataclass(frozen=True)
 class ModelConfig:
     """Configuration used to describe ML model.
 
-    Fields `n_outputs`, `tokenizer_groups` and `graph_hash` describe capabilities added after the first version of this
-    class. Their defaults describe a single-output model without tokenization, which is not tied to a particular graph,
-    so configs written before these fields existed keep working.
+    Fields `n_outputs`, `tokenizer_groups`, `graph_hash`, `backbone_type` and `v_consistency_weight` describe
+    capabilities added after the first version of this class. Their defaults describe a single-output model without
+    tokenization, which is not tied to a particular graph, so configs written before these fields existed keep working.
 
-    :param model_type: Type of the model, one of "MLP" (see :class:`MlpModel`) or "RESMLP"
-        (see :class:`ResMlpModel`).
+    :param model_type: Type of the model, one of "MLP" (see :class:`MlpModel`), "RESMLP"
+        (see :class:`ResMlpModel`) or "QV" (see :class:`QVModel`).
     :param input_size: Number of elements in one state.
     :param num_classes_for_one_hot: Number of distinct values one element of a state can take.
     :param layers_sizes: Sizes of hidden layers (for "RESMLP" these are sizes of residual blocks).
@@ -30,6 +32,10 @@ class ModelConfig:
         ``[group_size, num_groups]`` pairs. For example, ``[[3, 20], [2, 30]]`` means 20 tokens of 3 elements followed
         by 30 tokens of 2 elements. None means the state is not tokenized.
     :param graph_hash: Hash of the graph this model was trained for, see :func:`cayleypy.models.graph_hash`.
+    :param backbone_type: Type of the backbone for models built on top of another architecture (only "QV" needs it).
+        All other fields of this config describe that backbone.
+    :param v_consistency_weight: Weight of the v-consistency penalty applied by :class:`QVModel` when it scores
+        children. 0 means no penalty.
     """
 
     model_type: str
@@ -41,6 +47,8 @@ class ModelConfig:
     n_outputs: int = 1
     tokenizer_groups: Optional[list[list[int]]] = None
     graph_hash: Optional[str] = None
+    backbone_type: Optional[str] = None
+    v_consistency_weight: float = 0.0
 
     @staticmethod
     def from_dict(cfg: dict[str, Any]):
@@ -55,6 +63,8 @@ class ModelConfig:
             n_outputs=cfg.get("n_outputs", 1),
             tokenizer_groups=cfg.get("tokenizer_groups", None),
             graph_hash=cfg.get("graph_hash", None),
+            backbone_type=cfg.get("backbone_type", None),
+            v_consistency_weight=cfg.get("v_consistency_weight", 0.0),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -67,6 +77,8 @@ class ModelConfig:
             return MlpModel(self)
         elif self.model_type == "RESMLP":
             return ResMlpModel(self)
+        elif self.model_type == "QV":
+            return QVModel(self)
         else:
             raise ValueError("Unknown model type: " + self.model_type)
 

--- a/cayleypy/models/models.py
+++ b/cayleypy/models/models.py
@@ -35,7 +35,8 @@ class ModelConfig:
     :param backbone_type: Type of the backbone for models built on top of another architecture (only "QV" needs it).
         All other fields of this config describe that backbone.
     :param v_consistency_weight: Weight of the v-consistency penalty applied by :class:`QVModel` when it scores
-        children. 0 means no penalty.
+        children. 0 means no penalty, and it must stay 0 unless the V-head of the model was supervised during training
+        (see :class:`QVModel`).
     """
 
     model_type: str

--- a/cayleypy/models/models_test.py
+++ b/cayleypy/models/models_test.py
@@ -29,10 +29,12 @@ def test_from_dict_legacy():
     assert config.weights_kaggle_id == "fedimser/lrx-16/pyTorch/ep60/1"
     assert config.weights_path == "model_ep60.pth"
 
-    # Defaults describe single-output model without tokenization, not tied to any graph.
+    # Defaults describe single-output model without tokenization, not tied to any graph, without a backbone.
     assert config.n_outputs == 1
     assert config.tokenizer_groups is None
     assert config.graph_hash is None
+    assert config.backbone_type is None
+    assert config.v_consistency_weight == 0.0
 
 
 def test_from_dict_new_fields():
@@ -45,11 +47,15 @@ def test_from_dict_new_fields():
             "n_outputs": 12,
             "tokenizer_groups": [[3, 20], [2, 30]],
             "graph_hash": "abc123",
+            "backbone_type": "RESMLP",
+            "v_consistency_weight": 0.5,
         }
     )
     assert config.n_outputs == 12
     assert config.tokenizer_groups == [[3, 20], [2, 30]]
     assert config.graph_hash == "abc123"
+    assert config.backbone_type == "RESMLP"
+    assert config.v_consistency_weight == 0.5
 
 
 def test_to_dict_round_trip():

--- a/cayleypy/models/qv_model.py
+++ b/cayleypy/models/qv_model.py
@@ -30,6 +30,11 @@ class QVModel(nn.Module):
     children that both heads agree about. The penalty is not used during training: it only reranks children, and with
     ``v_consistency_weight=0`` (the default) scores are the Q-values as is.
 
+    The penalty is only meaningful for weights whose V-head was supervised. Training that fits :meth:`forward`, i.e.
+    the Q-head alone, leaves V at its initialization, and rescoring children against such a head makes predictions
+    worse, not better - so ``v_consistency_weight`` must stay 0 unless the loss that produced the weights had a term
+    for V.
+
     :meth:`forward` returns the Q-values, so this model is used through :meth:`cayleypy.Predictor.score_children` (which
     calls :meth:`score_children` of this model, so the penalty is applied). Estimates for the states themselves are
     available through :meth:`v`.

--- a/cayleypy/models/qv_model.py
+++ b/cayleypy/models/qv_model.py
@@ -1,0 +1,102 @@
+"""Model with two heads: one estimating distances for children of a state, another one for the state itself."""
+
+import typing
+from dataclasses import replace
+
+import torch
+from torch import nn
+
+if typing.TYPE_CHECKING:
+    from .models import ModelConfig
+
+
+class QVModel(nn.Module):
+    """Model with a Q-head (one output per generator) and a V-head (one output for the state itself).
+
+    This is the architecture used by AlphaZero-like solvers: `Q(s)[i]` estimates the distance from the central state to
+    the i-th child of `s`, and `V(s)` estimates the distance to `s` itself. Both heads are computed by the output layer
+    of the backbone (its first `n_outputs` values are Q, the last one is V), which is equivalent to two separate linear
+    heads over the features of the backbone and needs no parameters beyond them.
+
+    The backbone can be any other architecture known to :meth:`cayleypy.models.ModelConfig.build_model`; its type is
+    given by the `backbone_type` field of the config, and all other fields of the config describe it. So a config for
+    this model is the config of its backbone, with `model_type` set to "QV", `backbone_type` set to the type of the
+    backbone, and `n_outputs` set to the number of generators of the graph.
+
+    Having both heads allows to check them against each other at inference time (v-consistency): a child lying on an
+    optimal path from `s` must be at distance ``V(s)-1``, so a child whose Q-value disagrees with ``V(s)-1`` is
+    inconsistent, and probably mispredicted. :meth:`score_children` adds penalty
+    ``v_consistency_weight * |Q(s)[i] - (V(s)-1)|`` to the score of every child, which makes beam search prefer
+    children that both heads agree about. The penalty is not used during training: it only reranks children, and with
+    ``v_consistency_weight=0`` (the default) scores are the Q-values as is.
+
+    :meth:`forward` returns the Q-values, so this model is used through :meth:`cayleypy.Predictor.score_children` (which
+    calls :meth:`score_children` of this model, so the penalty is applied). Estimates for the states themselves are
+    available through :meth:`v`.
+
+    Example (Q+V model for a graph with 3 generators and 5 elements in a state):
+      >>> from cayleypy.models import ModelConfig
+      >>> config = ModelConfig(
+      ...     model_type="QV",
+      ...     input_size=5,
+      ...     num_classes_for_one_hot=5,
+      ...     layers_sizes=[64, 64],
+      ...     n_outputs=3,
+      ...     backbone_type="RESMLP",
+      ...     v_consistency_weight=0.1,
+      ... )
+      >>> model = config.build_model()
+      >>> model.n_outputs
+      3
+    """
+
+    def __init__(self, config: "ModelConfig"):
+        super().__init__()
+        assert config.model_type == "QV"
+        if config.n_outputs < 1:
+            raise ValueError(f"n_outputs must be positive, got {config.n_outputs}.")
+        if config.backbone_type is None:
+            raise ValueError(
+                'QVModel needs a backbone, but backbone_type is not set in the config. Set it to e.g. "RESMLP".'
+            )
+        if config.backbone_type == "QV":
+            raise ValueError('QVModel cannot be its own backbone, so backbone_type must not be "QV".')
+        if config.v_consistency_weight < 0:
+            raise ValueError(f"v_consistency_weight must be non-negative, got {config.v_consistency_weight}.")
+        self.n_outputs = config.n_outputs
+        self.v_consistency_weight = float(config.v_consistency_weight)
+        # The backbone has one output more than this model: the extra output is the V-head.
+        self.backbone = replace(config, model_type=config.backbone_type, n_outputs=self.n_outputs + 1).build_model()
+
+    def heads(self, states: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """Applies this model to `states`, returning outputs of both heads.
+
+        :param states: States (in decoded representation) to apply this model to.
+        :return: Pair (Q-values of shape ``[n_states, n_outputs]``, V-values of shape ``[n_states]``).
+        """
+        ans = self.backbone(states)
+        return ans[..., :-1], ans[..., -1]
+
+    def q(self, states: torch.Tensor) -> torch.Tensor:
+        """Estimated distances for all children of `states`, of shape ``[n_states, n_outputs]``."""
+        return self.heads(states)[0]
+
+    def v(self, states: torch.Tensor) -> torch.Tensor:
+        """Estimated distances for `states` themselves, of shape ``[n_states]``."""
+        return self.heads(states)[1]
+
+    def forward(self, states: torch.Tensor) -> torch.Tensor:
+        return self.q(states)
+
+    def score_children(self, states: torch.Tensor) -> torch.Tensor:
+        """Estimates distances for all children of `states`, penalizing children inconsistent with the V-head.
+
+        :param states: States (in decoded representation) whose children to score.
+        :return: Tensor of shape ``[n_states, n_outputs]`` with estimated distances for children.
+        """
+        q, v = self.heads(states)
+        if self.v_consistency_weight == 0:
+            return q
+        # A child of a state at distance V is at distance V-1 if it lies on an optimal path, so the further the Q-value
+        # of a child is from V-1, the less the heads agree about that child.
+        return q + self.v_consistency_weight * (q - (v.unsqueeze(-1) - 1.0)).abs()

--- a/cayleypy/models/qv_model_test.py
+++ b/cayleypy/models/qv_model_test.py
@@ -1,0 +1,199 @@
+import pytest
+import torch
+from torch import nn
+
+from .checkpoint import load_checkpoint, save_checkpoint
+from .models import ModelConfig, ResMlpModel
+from .qv_model import QVModel
+from ..cayley_graph import CayleyGraph
+from ..graphs_lib import PermutationGroups
+from ..predictor import Predictor
+
+# Two states of a graph with input_size=5 and num_classes_for_one_hot=5.
+STATES = torch.tensor([[0, 1, 2, 3, 4], [4, 3, 2, 1, 0]])
+
+
+def qv_config(n_outputs: int = 3, backbone_type: str = "RESMLP", v_consistency_weight: float = 0.0) -> ModelConfig:
+    return ModelConfig(
+        model_type="QV",
+        input_size=5,
+        num_classes_for_one_hot=5,
+        layers_sizes=[8, 8],
+        n_outputs=n_outputs,
+        backbone_type=backbone_type,
+        v_consistency_weight=v_consistency_weight,
+    )
+
+
+def set_constant_heads(model: QVModel, q_values: list[float], v_value: float) -> None:
+    """Makes the model return given values for any state, by zeroing weights of the output layer of the backbone."""
+    head = model.backbone.head
+    assert isinstance(head, nn.Linear)
+    with torch.no_grad():
+        head.weight.zero_()
+        head.bias.copy_(torch.tensor(q_values + [v_value]))
+
+
+def test_build_qv_model():
+    model = qv_config().build_model()
+    assert isinstance(model, QVModel)
+    assert isinstance(model.backbone, ResMlpModel)
+
+    # The model has as many outputs as there are generators, and the backbone has one more (for the V-head).
+    assert model.n_outputs == 3
+    assert model.backbone.n_outputs == 4
+
+
+def test_qv_model_heads_shapes():
+    model = qv_config(n_outputs=4).build_model()
+    q, v = model.heads(STATES)
+    assert q.shape == (2, 4)
+    assert v.shape == (2,)
+    assert torch.equal(model.q(STATES), q)
+    assert torch.equal(model.v(STATES), v)
+
+    # Q-values are what this model returns when called, so it can be used as a Q-model.
+    assert torch.equal(model(STATES), q)
+
+
+def test_qv_model_with_mlp_backbone():
+    model = qv_config(backbone_type="MLP").build_model()
+    q, v = model.heads(STATES)
+    assert q.shape == (2, 3)
+    assert v.shape == (2,)
+
+
+def test_qv_model_single_state():
+    model = qv_config().build_model()
+    q, v = model.heads(torch.tensor([0, 1, 2, 3, 4]))
+    assert q.shape == (3,)
+    assert v.shape == ()
+
+
+def test_v_consistency_penalty_is_off_by_default():
+    model = qv_config().build_model()
+    assert model.v_consistency_weight == 0
+
+    # Without the penalty, children scores are the Q-values as is.
+    assert torch.equal(model.score_children(STATES), model.q(STATES))
+
+
+def test_v_consistency_penalty_demotes_inconsistent_child():
+    # Q says the second child is the closest one to the central state, but the V-head says this state is at distance 4,
+    # so a child on an optimal path must be at distance 3 - which is what Q says about the first child only.
+    model = qv_config(n_outputs=2, v_consistency_weight=2.0).build_model()
+    set_constant_heads(model, [3.0, 2.0], 4.0)
+
+    with torch.no_grad():
+        assert torch.allclose(model.q(STATES), torch.tensor([[3.0, 2.0], [3.0, 2.0]]))
+        assert torch.allclose(model.v(STATES), torch.tensor([4.0, 4.0]))
+        scores = model.score_children(STATES)
+
+    # Score of the first child is unchanged (its Q agrees with V-1), the second one is penalized by 2*|2-3|=2.
+    assert torch.allclose(scores, torch.tensor([[3.0, 4.0], [3.0, 4.0]]))
+
+    # The penalty changed which child looks the best.
+    assert int(torch.argmin(model.q(STATES)[0])) == 1
+    assert int(torch.argmin(scores[0])) == 0
+
+
+def test_v_consistency_penalty_grows_with_weight():
+    model = qv_config(n_outputs=2, v_consistency_weight=0.5).build_model()
+    set_constant_heads(model, [3.0, 2.0], 4.0)
+    with torch.no_grad():
+        assert torch.allclose(model.score_children(STATES)[0], torch.tensor([3.0, 2.5]))
+
+        # The penalty is proportional to the weight.
+        model.v_consistency_weight = 1.0
+        assert torch.allclose(model.score_children(STATES)[0], torch.tensor([3.0, 3.0]))
+
+
+def test_qv_model_checkpoint_round_trip(tmp_path):
+    graph_def = PermutationGroups.lrx(5)
+    config = qv_config(n_outputs=graph_def.n_generators, v_consistency_weight=0.25)
+    model = QVModel(config)
+    set_constant_heads(model, [1.0, 2.0, 3.0], 4.0)
+    path = tmp_path / "qv.pt"
+    saved_config = save_checkpoint(path, model, config, graph_def)
+
+    loaded_model, loaded_config = load_checkpoint(path, graph_def=graph_def)
+
+    # Config in the checkpoint fully describes the model, including its backbone and the penalty weight.
+    assert loaded_config == saved_config
+    assert loaded_config.backbone_type == "RESMLP"
+    assert loaded_config.v_consistency_weight == 0.25
+    assert loaded_config.graph_hash is not None
+    assert isinstance(loaded_model, QVModel)
+    with torch.no_grad():
+        assert torch.equal(loaded_model.score_children(STATES), model.score_children(STATES))
+
+
+def test_qv_model_state_dict_keys():
+    model = qv_config().build_model()
+
+    # All weights of this model belong to its backbone (both heads are computed by the output layer of the backbone).
+    assert all(key.startswith("backbone.") for key in model.state_dict())
+    assert model.state_dict()["backbone.head.weight"].shape == (4, 8)
+
+
+def test_predictor_uses_score_children_of_the_model():
+    graph_def = PermutationGroups.lrx(5)
+    graph = CayleyGraph(graph_def, device="cpu")
+    model = qv_config(n_outputs=graph_def.n_generators, v_consistency_weight=2.0).build_model()
+    set_constant_heads(model, [3.0, 2.0, 2.0], 4.0)
+    predictor = Predictor(graph, model)
+
+    # The penalty is applied when Predictor scores children, so beam search sees consistency-corrected scores.
+    scores = predictor.score_children(STATES)
+    assert scores.shape == (2, graph_def.n_generators)
+    assert torch.allclose(scores, torch.tensor([[3.0, 4.0, 4.0]] * 2))
+
+
+def test_predictor_batches_score_children_of_the_model():
+    graph_def = PermutationGroups.lrx(5)
+    graph = CayleyGraph(graph_def, device="cpu", batch_size=3)
+    model = qv_config(n_outputs=graph_def.n_generators, v_consistency_weight=0.5).build_model()
+    model.eval()
+    predictor = Predictor(graph, model)
+    states = torch.tensor([[i % 5, (i + 1) % 5, 2, 3, 4] for i in range(7)])
+
+    # States are scored in several batches, which must not change the answer.
+    scores = predictor.score_children(states)
+    assert scores.shape == (7, graph_def.n_generators)
+    with torch.no_grad():
+        for i in range(7):
+            assert torch.allclose(scores[i : i + 1], model.score_children(states[i : i + 1]), atol=1e-6)
+
+
+def test_qv_model_without_backbone_type():
+    config = ModelConfig(model_type="QV", input_size=5, num_classes_for_one_hot=5, layers_sizes=[8], n_outputs=3)
+    with pytest.raises(ValueError, match="backbone_type is not set"):
+        config.build_model()
+
+
+def test_qv_model_with_unknown_backbone_type():
+    with pytest.raises(ValueError, match="Unknown model type: NoSuchModel"):
+        qv_config(backbone_type="NoSuchModel").build_model()
+
+
+def test_qv_model_with_itself_as_backbone():
+    with pytest.raises(ValueError, match="cannot be its own backbone"):
+        qv_config(backbone_type="QV").build_model()
+
+
+def test_qv_model_with_negative_v_consistency_weight():
+    with pytest.raises(ValueError, match="v_consistency_weight must be non-negative"):
+        qv_config(v_consistency_weight=-0.5).build_model()
+
+
+def test_qv_model_with_non_positive_n_outputs():
+    with pytest.raises(ValueError, match="n_outputs must be positive"):
+        qv_config(n_outputs=0).build_model()
+
+
+def test_predictor_rejects_qv_model_with_wrong_number_of_outputs():
+    graph_def = PermutationGroups.lrx(5)
+    graph = CayleyGraph(graph_def, device="cpu")
+    predictor = Predictor(graph, qv_config(n_outputs=graph_def.n_generators + 1).build_model())
+    with pytest.raises(ValueError, match="but the graph has 3 generators"):
+        predictor.score_children(STATES)

--- a/cayleypy/predictor.py
+++ b/cayleypy/predictor.py
@@ -1,6 +1,6 @@
 import math
 import typing
-from typing import Callable
+from typing import Callable, Optional
 
 import torch
 
@@ -33,10 +33,17 @@ class Predictor:
             there are generators in `graph`, and must declare their number in attribute ``n_outputs`` - then
             :meth:`score_children` will call it once per state instead of once per child. Models built by
             :meth:`cayleypy.models.ModelConfig.build_model` declare it automatically.
+
+            A model that has its own way to score children (i.e. has method ``score_children``, e.g.
+            :class:`cayleypy.models.QVModel`) will be asked for children scores through that method.
         """
         self.graph = graph
         self.predict = lambda x: x  # type: Callable[[torch.Tensor], torch.Tensor]
         self.n_outputs = int(getattr(models_or_heuristics, "n_outputs", 1))
+        # Not None if the model scores children itself (see score_children).
+        self._model_score_children = getattr(
+            models_or_heuristics, "score_children", None
+        )  # type: Optional[Callable[[torch.Tensor], torch.Tensor]]
 
         if models_or_heuristics == "zero":
             self.predict = lambda x: torch.zeros((x.shape[0],))
@@ -61,6 +68,18 @@ class Predictor:
         model = PREDICTOR_MODELS[graph.definition.name].load(graph.device)
         return Predictor(graph, model)
 
+    def _apply_batched(self, func: Callable[[torch.Tensor], torch.Tensor], states: torch.Tensor) -> torch.Tensor:
+        """Applies `func` to `states`, splitting them into batches if there are too many."""
+        num_batches = int(math.ceil(states.shape[0] / self.graph.batch_size))
+        if num_batches > 1:
+            ans = []  # type: list[torch.Tensor]
+            for batch in states.tensor_split(num_batches, dim=0):
+                ans.append(func(batch))
+            # Batches must be concatenated along dimension 0, otherwise outputs of multi-output models are mangled.
+            return torch.cat(ans, dim=0)
+        else:
+            return func(states)
+
     def predict_batched(self, states: torch.Tensor) -> torch.Tensor:
         """Applies the underlying model to `states`, splitting them into batches if there are too many.
 
@@ -70,15 +89,7 @@ class Predictor:
         :param states: States (in decoded representation) to apply the model to.
         :return: Output of the model for `states`.
         """
-        num_batches = int(math.ceil(states.shape[0] / self.graph.batch_size))
-        if num_batches > 1:
-            ans = []  # type: list[torch.Tensor]
-            for batch in states.tensor_split(num_batches, dim=0):
-                ans.append(self.predict(batch))
-            # Batches must be concatenated along dimension 0, otherwise outputs of multi-output models are mangled.
-            return torch.cat(ans, dim=0)
-        else:
-            return self.predict(states)
+        return self._apply_batched(self.predict, states)
 
     def __call__(self, states: torch.Tensor) -> torch.Tensor:
         ans = self.predict_batched(states)
@@ -95,8 +106,11 @@ class Predictor:
         Children are enumerated in the order of generators: element ``[i, j]`` of the answer is the estimated distance
         for the state obtained by applying generator ``j`` to ``states[i]``.
 
-        For a model having one output per generator (Q-model, i.e. ``n_outputs == n_generators``), the answer is the
-        output of the model applied to `states`, so one model evaluation per state is needed.
+        If the model scores children itself (i.e. has method ``score_children``, e.g.
+        :class:`cayleypy.models.QVModel`), that method is called for `states`.
+
+        Otherwise, for a model having one output per generator (Q-model, i.e. ``n_outputs == n_generators``), the answer
+        is the output of the model applied to `states`, so one model evaluation per state is needed.
 
         Otherwise (for a single-output model), the model is called for every child, which needs `n_generators` times
         more model evaluations than :meth:`__call__`.
@@ -107,14 +121,15 @@ class Predictor:
         n_generators = self.graph.definition.n_generators
         encoded_states = self.graph.encode_states(states)
         num_states = int(encoded_states.shape[0])
-        if self.n_outputs != 1:
-            if self.n_outputs != n_generators:
-                raise ValueError(
-                    f"Model has {self.n_outputs} outputs, but the graph has {n_generators} generators. Model used to "
-                    "score children must have either 1 output (for the state it is applied to), or one output per "
-                    "generator (for every child of that state)."
-                )
-            scores = self.predict_batched(self.graph.decode_states(encoded_states))
+        if self.n_outputs not in (1, n_generators):
+            raise ValueError(
+                f"Model has {self.n_outputs} outputs, but the graph has {n_generators} generators. Model used to "
+                "score children must have either 1 output (for the state it is applied to), or one output per "
+                "generator (for every child of that state)."
+            )
+        if self._model_score_children is not None or self.n_outputs != 1:
+            func = self._model_score_children if self._model_score_children is not None else self.predict
+            scores = self._apply_batched(func, self.graph.decode_states(encoded_states))
             if tuple(scores.shape) != (num_states, n_generators):
                 raise ValueError(
                     f"Model returned output of shape {tuple(scores.shape)}, but shape "

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -45,6 +45,7 @@ Beam search and ML
     cayleypy.models.ModelConfig
     cayleypy.models.MlpModel
     cayleypy.models.ResMlpModel
+    cayleypy.models.QVModel
     cayleypy.models.graph_hash
     cayleypy.models.save_checkpoint
     cayleypy.models.load_checkpoint


### PR DESCRIPTION
Depends on #3 (multi-output models and the `score_children` fast path), which depends on #1. Base of this PR is `feat/resmlp-qmlp`, so it stays a draft until #3 is merged.

## What

`QVModel` (`model_type="QV"`) - the architecture used by AlphaZero-like solvers:

- **Q-head**: one output per generator, estimating distances for all children of a state.
- **V-head**: one output, estimating the distance for the state itself.

Both heads are computed by the output layer of the backbone (its first `n_outputs` values are Q, the last one is V), which is equivalent to two separate linear heads over the features of the backbone and needs no parameters beyond them.

The backbone is any architecture known to `ModelConfig.build_model` (`MLP`/`RESMLP` today, `TRANSFORMER` from #5 once it is merged). Its type is given by the new flat config field `backbone_type`, and all other fields of the config describe that backbone - so no nested config and no duplicated `input_size`/`num_classes_for_one_hot`, and a checkpoint still fully describes the model.

## v-consistency (inference time only)

A child lying on an optimal path from `s` must be at distance `V(s)-1`, so a child whose Q-value disagrees with `V(s)-1` is probably mispredicted. `QVModel.score_children` adds `v_consistency_weight * |Q(s)[i] - (V(s)-1)|` to the score of every child, which makes beam search prefer children that both heads agree about. With the default `v_consistency_weight=0` scores are the Q-values as is.

This is reranking, not training, so the `Predictor` API is unchanged: `Predictor.score_children` now asks a model that has its own `score_children` (any model, not only this one) for children scores, batching it the same way as ordinary predictions. That is the only way the penalty reaches beam search, which calls `Predictor.score_children` (see #2).

## Tests

17 new tests in `cayleypy/models/qv_model_test.py`: shapes of both heads (batch and single state, MLP and ResMLP backbones), penalty demotes a child whose Q contradicts `V-1` and is proportional to the weight, penalty off by default, checkpoint round-trip (config including `backbone_type`, `v_consistency_weight` and `graph_hash`; scores after loading are identical), all weights live under `backbone.*`, `Predictor` applies the model's own `score_children` and batches it, plus errors: no `backbone_type`, unknown backbone type, `QV` as its own backbone, negative `v_consistency_weight`, non-positive `n_outputs`, `n_outputs` disagreeing with the number of generators. `models_test.py` covers the two new config fields in `from_dict`.

`./lint.sh` (black, pylint 10.00/10, mypy) and `black --check .` are green; `RUN_SLOW_TESTS=1 pytest` gives 352 passed / 12 skipped / 3 xfailed on Python 3.12 (torch 2.13) and on Python 3.9 (torch 2.8); docs build with `-W` is green.

## Weights

#11 registers the first model trained with the trainer (#9, #10) in `PREDICTOR_MODELS`, which makes the whole path — training, checkpoint, registry, beam search scoring children — a tested one; its backbone is `RESMLP`, the same kind of backbone this model wraps. Weights for a `QV` model itself come from a training run with `v_consistency_weight` turned on, tracked in the series.



---

Based on #193, which is the base branch of this PR, so this diff is only its own change. #193 should be merged first.
