### PR TITLE
Add Q-transformer model consuming tokenized states

### DIFF
--- a/cayleypy/models/__init__.py
+++ b/cayleypy/models/__init__.py
@@ -1,3 +1,4 @@
 from .checkpoint import graph_hash, load_checkpoint, save_checkpoint
 from .models import ModelConfig
 from .tokenizer import GroupTokenizer
+from .transformer import TransformerModel

--- a/cayleypy/models/models.py
+++ b/cayleypy/models/models.py
@@ -8,6 +8,8 @@ import kagglehub
 import torch
 from torch import nn
 
+from .transformer import TransformerModel
+
 
 @dataclass(frozen=True)
 class ModelConfig:
@@ -29,6 +31,9 @@ class ModelConfig:
         ``[group_size, num_groups]`` pairs. For example, ``[[3, 20], [2, 30]]`` means 20 tokens of 3 elements followed
         by 30 tokens of 2 elements. None means the state is not tokenized.
     :param graph_hash: Hash of the graph this model was trained for, see :func:`cayleypy.models.graph_hash`.
+    :param n_heads: Number of attention heads, for models with attention. None means one head per 64 features.
+    :param dim_feedforward: Width of the feed-forward layer inside a transformer block. None means 4 times the width
+        of the model.
     """
 
     model_type: str
@@ -40,6 +45,8 @@ class ModelConfig:
     n_outputs: int = 1
     tokenizer_groups: Optional[list[list[int]]] = None
     graph_hash: Optional[str] = None
+    n_heads: Optional[int] = None
+    dim_feedforward: Optional[int] = None
 
     @staticmethod
     def from_dict(cfg: dict[str, Any]):
@@ -54,6 +61,8 @@ class ModelConfig:
             n_outputs=cfg.get("n_outputs", 1),
             tokenizer_groups=cfg.get("tokenizer_groups", None),
             graph_hash=cfg.get("graph_hash", None),
+            n_heads=cfg.get("n_heads", None),
+            dim_feedforward=cfg.get("dim_feedforward", None),
         )
 
     def to_dict(self) -> dict[str, Any]:
@@ -64,6 +73,8 @@ class ModelConfig:
         """Creates model described by this config, with randomly initialized weights."""
         if self.model_type == "MLP":
             return MlpModel(self)
+        elif self.model_type == "TRANSFORMER":
+            return TransformerModel(self)
         else:
             raise ValueError("Unknown model type: " + self.model_type)
 

--- a/cayleypy/models/models.py
+++ b/cayleypy/models/models.py
@@ -15,9 +15,9 @@ from .transformer import TransformerModel
 class ModelConfig:
     """Configuration used to describe ML model.
 
-    Fields `n_outputs`, `tokenizer_groups` and `graph_hash` describe capabilities added after the first version of this
-    class. Their defaults describe a single-output model without tokenization, which is not tied to a particular graph,
-    so configs written before these fields existed keep working.
+    Fields `n_outputs`, `tokenizer_groups`, `graph_hash`, `n_heads` and `dim_feedforward` describe capabilities added
+    after the first version of this class. Their defaults describe a single-output model without tokenization, which is
+    not tied to a particular graph, so configs written before these fields existed keep working.
 
     :param model_type: Type of the model, e.g. "MLP".
     :param input_size: Number of elements in one state.

--- a/cayleypy/models/models_test.py
+++ b/cayleypy/models/models_test.py
@@ -25,10 +25,12 @@ def test_from_dict_legacy():
     assert config.weights_kaggle_id == "fedimser/lrx-16/pyTorch/ep60/1"
     assert config.weights_path == "model_ep60.pth"
 
-    # Defaults describe single-output model without tokenization, not tied to any graph.
+    # Defaults describe single-output model without tokenization and without attention, not tied to any graph.
     assert config.n_outputs == 1
     assert config.tokenizer_groups is None
     assert config.graph_hash is None
+    assert config.n_heads is None
+    assert config.dim_feedforward is None
 
 
 def test_from_dict_new_fields():
@@ -41,11 +43,15 @@ def test_from_dict_new_fields():
             "n_outputs": 12,
             "tokenizer_groups": [[3, 20], [2, 30]],
             "graph_hash": "abc123",
+            "n_heads": 8,
+            "dim_feedforward": 1024,
         }
     )
     assert config.n_outputs == 12
     assert config.tokenizer_groups == [[3, 20], [2, 30]]
     assert config.graph_hash == "abc123"
+    assert config.n_heads == 8
+    assert config.dim_feedforward == 1024
 
 
 def test_to_dict_round_trip():
@@ -57,6 +63,8 @@ def test_to_dict_round_trip():
         n_outputs=12,
         tokenizer_groups=[[3, 20], [2, 30]],
         graph_hash="abc123",
+        n_heads=8,
+        dim_feedforward=1024,
     )
     as_dict = config.to_dict()
 

--- a/cayleypy/models/tokenizer.py
+++ b/cayleypy/models/tokenizer.py
@@ -5,10 +5,9 @@ from typing import Sequence
 
 import torch
 
-from .models import ModelConfig
-
 if typing.TYPE_CHECKING:
     from ..cayley_graph_def import CayleyGraphDef
+    from .models import ModelConfig
 
 
 class GroupTokenizer:
@@ -87,7 +86,7 @@ class GroupTokenizer:
         """Index of the segment each token belongs to, of shape ``[n_tokens]``."""
 
     @staticmethod
-    def from_config(config: ModelConfig) -> "GroupTokenizer":
+    def from_config(config: "ModelConfig") -> "GroupTokenizer":
         """Creates tokenizer described by `tokenizer_groups` field of the given model config.
 
         :param config: Config of a model that consumes tokens.

--- a/cayleypy/models/transformer.py
+++ b/cayleypy/models/transformer.py
@@ -1,0 +1,125 @@
+"""Transformer model consuming states as sequences of tokens."""
+
+import typing
+
+import torch
+from torch import nn
+
+from .tokenizer import GroupTokenizer
+
+if typing.TYPE_CHECKING:
+    from .models import ModelConfig
+
+# Number of features per attention head, used when the number of heads is not set explicitly in the config.
+DEFAULT_FEATURES_PER_HEAD = 64
+
+# Ratio of the feed-forward layer width to the model width, used when the former is not set explicitly in the config.
+DEFAULT_FEEDFORWARD_MULTIPLIER = 4
+
+
+class TransformerModel(nn.Module):
+    """Transformer encoder over tokens of a state.
+
+    A state is converted to tokens by :class:`cayleypy.models.GroupTokenizer` (one token per puzzle piece, as described
+    by the `tokenizer_groups` field of the config). Tokens are embedded, their embeddings are summed with a learnable
+    positional embedding and with an embedding of the token type (so the model can tell corners from edges), and the
+    resulting sequence is processed by ``torch.nn.TransformerEncoder``. Encoded tokens are averaged, and a linear layer
+    with `n_outputs` neurons is applied to the average.
+
+    Blocks of the encoder are pre-norm (normalization before attention and before the feed-forward layer), use GELU
+    activation and no dropout, so the model is deterministic in evaluation mode.
+
+    The config describes this model as follows:
+
+    - `layers_sizes` has one entry per encoder layer, and all entries must be equal (a transformer encoder keeps the
+      same number of features in all layers), so ``[256] * 4`` means 4 layers of width 256;
+    - `n_heads` and `dim_feedforward` are optional; by default there is one attention head per 64 features, and the
+      feed-forward layer is 4 times wider than the model;
+    - `tokenizer_groups` is required, and `num_classes_for_one_hot` is not used (the size of the vocabulary is
+      determined by `tokenizer_groups`);
+    - `n_outputs` set to the number of generators of a graph gives a Q-model, which estimates distances for all
+      children of a state in a single forward pass (see :meth:`cayleypy.Predictor.score_children`).
+
+    Output has shape ``[n_states]`` when ``n_outputs == 1``, and shape ``[n_states, n_outputs]`` otherwise.
+
+    Example (Q-model for Megaminx, which has 120 elements in a state and 24 generators):
+      >>> from cayleypy.models import ModelConfig
+      >>> config = ModelConfig(
+      ...     model_type="TRANSFORMER",
+      ...     input_size=120,
+      ...     num_classes_for_one_hot=60,
+      ...     layers_sizes=[256] * 4,
+      ...     n_outputs=24,
+      ...     tokenizer_groups=[[3, 20], [2, 30]],
+      ...     n_heads=8,
+      ...     dim_feedforward=1024,
+      ... )
+      >>> model = config.build_model()
+      >>> model.n_outputs
+      24
+    """
+
+    def __init__(self, config: "ModelConfig"):
+        super().__init__()
+        assert config.model_type == "TRANSFORMER"
+        if config.n_outputs < 1:
+            raise ValueError(f"n_outputs must be positive, got {config.n_outputs}.")
+        if len(config.layers_sizes) == 0:
+            raise ValueError("TransformerModel needs at least one encoder layer, but layers_sizes is empty.")
+        if len(set(config.layers_sizes)) != 1:
+            raise ValueError(
+                f"All encoder layers must have the same width, got layers_sizes={config.layers_sizes}. Use "
+                "[width] * num_layers."
+            )
+        d_model = config.layers_sizes[0]
+        n_heads = config.n_heads if config.n_heads is not None else max(1, d_model // DEFAULT_FEATURES_PER_HEAD)
+        if n_heads < 1:
+            raise ValueError(f"n_heads must be positive, got {n_heads}.")
+        if d_model % n_heads != 0:
+            raise ValueError(f"Model width {d_model} must be divisible by the number of attention heads {n_heads}.")
+        if config.dim_feedforward is not None:
+            dim_feedforward = config.dim_feedforward
+            if dim_feedforward < 1:
+                raise ValueError(f"dim_feedforward must be positive, got {dim_feedforward}.")
+        else:
+            dim_feedforward = DEFAULT_FEEDFORWARD_MULTIPLIER * d_model
+
+        self.n_outputs = config.n_outputs
+        self.tokenizer = GroupTokenizer.from_config(config)
+        self.token_embedding = nn.Embedding(self.tokenizer.vocab_size, d_model)
+        self.token_type_embedding = nn.Embedding(self.tokenizer.n_token_types, d_model)
+        self.position_embedding = nn.Parameter(torch.empty(self.tokenizer.n_tokens, d_model))
+        nn.init.normal_(self.position_embedding, std=0.02)
+        encoder_layer = nn.TransformerEncoderLayer(
+            d_model=d_model,
+            nhead=n_heads,
+            dim_feedforward=dim_feedforward,
+            dropout=0.0,
+            activation="gelu",
+            batch_first=True,
+            norm_first=True,
+        )
+        self.encoder = nn.TransformerEncoder(
+            encoder_layer,
+            num_layers=len(config.layers_sizes),
+            norm=nn.LayerNorm(d_model),
+            # All states have the same number of tokens and there is no padding, so nested tensors give nothing here.
+            enable_nested_tensor=False,
+        )
+        self.head = nn.Linear(d_model, self.n_outputs)
+
+        # Not persistent: this is derived from `tokenizer_groups` in the config, so it must not be in the state dict.
+        self.register_buffer("token_type_ids", self.tokenizer.token_type_ids, persistent=False)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        single_state = x.dim() == 1
+        if single_state:
+            x = x.unsqueeze(0)
+        tokens = self.tokenizer(x)
+        embedded = self.token_embedding(tokens) + self.token_type_embedding(self.token_type_ids)
+        encoded = self.encoder(embedded + self.position_embedding)
+        ans = self.head(encoded.mean(dim=1))
+        # For single-output models the trailing dimension of size 1 is removed, so there is one score per state.
+        if self.n_outputs == 1:
+            ans = ans.squeeze(-1)
+        return ans.squeeze(0) if single_state else ans

--- a/cayleypy/models/transformer_test.py
+++ b/cayleypy/models/transformer_test.py
@@ -113,6 +113,23 @@ def test_output_does_not_depend_on_batch_size():
         assert torch.allclose(scores[i], model(states[i]), atol=1e-6)
 
 
+def test_output_depends_on_the_state():
+    # Shapes and batch independence hold for a model that ignores its input, and such a model is useless as a
+    # predictor, so it is checked that different states get different scores.
+    torch.manual_seed(0)
+    graph_def = Puzzles.mini_pyramorphix()
+    model = _config(n_outputs=graph_def.n_generators).build_model()
+    model.eval()
+    states = _random_states(graph_def, 6)
+    n_distinct_states = len({tuple(state) for state in states.tolist()})
+    assert n_distinct_states > 1
+
+    scores = model(states)
+    assert len({tuple(row) for row in scores.tolist()}) == n_distinct_states
+    # The same state always gets the same scores.
+    assert torch.allclose(model(states[2]), scores[2], atol=1e-6)
+
+
 def test_checkpoint_round_trip(tmp_path):
     torch.manual_seed(0)
     graph_def = Puzzles.mini_pyramorphix()

--- a/cayleypy/models/transformer_test.py
+++ b/cayleypy/models/transformer_test.py
@@ -142,6 +142,10 @@ def test_checkpoint_round_trip(tmp_path):
     save_checkpoint(path, model, config, graph_def)
     loaded_model, loaded_config = load_checkpoint(path, graph_def=graph_def)
 
+    # Token types are derived from `tokenizer_groups`, so they must not be in the state dict: a published checkpoint
+    # written with them in it would not load into a model built by a version that derives them.
+    assert "token_type_ids" not in model.state_dict()
+
     assert isinstance(loaded_model, TransformerModel)
     assert loaded_config.n_heads == 4
     assert loaded_config.dim_feedforward == 48

--- a/cayleypy/models/transformer_test.py
+++ b/cayleypy/models/transformer_test.py
@@ -1,0 +1,183 @@
+import pytest
+import torch
+
+from .checkpoint import load_checkpoint, save_checkpoint
+from .models import ModelConfig
+from .transformer import TransformerModel
+from ..cayley_graph import CayleyGraph
+from ..predictor import Predictor
+from ..puzzles import Puzzles
+
+# Megaminx: 20 corners with 3 stickers each, then 30 edges with 2 stickers each.
+MEGAMINX_GROUPS = [[3, 20], [2, 30]]
+
+# Mini pyramorphix: 8 pieces with 3 stickers each, 17 generators.
+PYRAMORPHIX_GROUPS = [[3, 8]]
+
+
+def _config(**kwargs) -> ModelConfig:
+    """Config of a small transformer for mini pyramorphix, with fields overridden by `kwargs`."""
+    defaults = {
+        "model_type": "TRANSFORMER",
+        "input_size": 24,
+        "num_classes_for_one_hot": 24,
+        "layers_sizes": [16, 16],
+        "tokenizer_groups": PYRAMORPHIX_GROUPS,
+    }
+    defaults.update(kwargs)
+    return ModelConfig(**defaults)  # type: ignore[arg-type]
+
+
+def _random_states(graph_def, n_states: int) -> torch.Tensor:
+    """Random states of the given graph, obtained by applying random generators to the central state."""
+    generator = torch.Generator().manual_seed(42)
+    state = torch.tensor(graph_def.central_state)
+    states = []
+    for _ in range(n_states):
+        move = int(torch.randint(graph_def.n_generators, (1,), generator=generator).item())
+        state = state[torch.tensor(graph_def.generators_permutations[move])]
+        states.append(state)
+    return torch.stack(states)
+
+
+def test_output_shape_single_output():
+    torch.manual_seed(0)
+    model = _config().build_model()
+    assert isinstance(model, TransformerModel)
+    assert model.n_outputs == 1
+
+    states = _random_states(Puzzles.mini_pyramorphix(), 5)
+    assert model(states).shape == (5,)
+
+    # A single state (1-D input) is scored to a single number, like for other models.
+    assert model(states[0]).shape == ()
+
+
+def test_output_shape_q_model():
+    torch.manual_seed(0)
+    graph_def = Puzzles.mini_pyramorphix()
+    model = _config(n_outputs=graph_def.n_generators).build_model()
+    assert model.n_outputs == 17
+
+    states = _random_states(graph_def, 5)
+    assert model(states).shape == (5, 17)
+    assert model(states[0]).shape == (17,)
+
+
+def test_megaminx_config():
+    # Config from the docstring, but narrow, so the test is fast.
+    torch.manual_seed(0)
+    graph_def = Puzzles.megaminx()
+    config = ModelConfig(
+        model_type="TRANSFORMER",
+        input_size=120,
+        num_classes_for_one_hot=60,
+        layers_sizes=[32] * 2,
+        n_outputs=graph_def.n_generators,
+        tokenizer_groups=MEGAMINX_GROUPS,
+        n_heads=8,
+        dim_feedforward=64,
+    )
+    model = config.build_model()
+    assert model.tokenizer.n_tokens == 50
+    assert model.token_embedding.num_embeddings == 60  # Vocabulary is determined by the tokenizer, not by the config.
+    assert model.token_type_embedding.num_embeddings == 2  # Corners and edges.
+    assert model.position_embedding.shape == (50, 32)
+    assert len(model.encoder.layers) == 2
+
+    states = _random_states(graph_def, 3)
+    assert model(states).shape == (3, 24)
+
+
+def test_defaults_for_heads_and_feedforward():
+    torch.manual_seed(0)
+    model = _config(layers_sizes=[128, 128, 128]).build_model()
+    assert len(model.encoder.layers) == 3
+    # One head per 64 features, feed-forward layer 4 times wider than the model.
+    assert model.encoder.layers[0].self_attn.num_heads == 2
+    assert model.encoder.layers[0].linear1.out_features == 512
+
+    # For a narrow model, the default is a single attention head.
+    assert _config(layers_sizes=[16]).build_model().encoder.layers[0].self_attn.num_heads == 1
+
+
+def test_output_does_not_depend_on_batch_size():
+    torch.manual_seed(0)
+    model = _config(n_outputs=17).build_model()
+    model.eval()
+    states = _random_states(Puzzles.mini_pyramorphix(), 6)
+
+    scores = model(states)
+    assert torch.allclose(scores[:2], model(states[:2]), atol=1e-6)
+    for i in range(6):
+        assert torch.allclose(scores[i], model(states[i]), atol=1e-6)
+
+
+def test_checkpoint_round_trip(tmp_path):
+    torch.manual_seed(0)
+    graph_def = Puzzles.mini_pyramorphix()
+    config = _config(n_outputs=graph_def.n_generators, n_heads=4, dim_feedforward=48)
+    model = config.build_model()
+    states = _random_states(graph_def, 4)
+    expected = model(states)
+
+    path = tmp_path / "transformer.pt"
+    save_checkpoint(path, model, config, graph_def)
+    loaded_model, loaded_config = load_checkpoint(path, graph_def=graph_def)
+
+    assert isinstance(loaded_model, TransformerModel)
+    assert loaded_config.n_heads == 4
+    assert loaded_config.dim_feedforward == 48
+    assert loaded_config.tokenizer_groups == PYRAMORPHIX_GROUPS
+    assert torch.allclose(loaded_model(states), expected, atol=1e-6)
+
+
+def test_works_as_predictor():
+    torch.manual_seed(0)
+    graph = CayleyGraph(Puzzles.mini_pyramorphix(), device="cpu")
+    predictor = Predictor(graph, _config().build_model())
+    states = _random_states(graph.definition, 3)
+
+    assert predictor(states).shape == (3,)
+    # Default implementation of score_children applies this single-output model to all children of every state.
+    assert predictor.score_children(states).shape == (3, 17)
+
+
+def test_without_tokenizer_groups():
+    with pytest.raises(ValueError, match="tokenizer_groups"):
+        _config(tokenizer_groups=None).build_model()
+
+
+def test_tokenizer_groups_inconsistent_with_input_size():
+    with pytest.raises(ValueError, match="input_size in the config is 25"):
+        _config(input_size=25).build_model()
+
+
+def test_no_layers():
+    with pytest.raises(ValueError, match="layers_sizes is empty"):
+        _config(layers_sizes=[]).build_model()
+
+
+def test_layers_of_different_width():
+    with pytest.raises(ValueError, match="All encoder layers must have the same width"):
+        _config(layers_sizes=[16, 32]).build_model()
+
+
+def test_width_not_divisible_by_number_of_heads():
+    with pytest.raises(ValueError, match="must be divisible by the number of attention heads"):
+        _config(layers_sizes=[16, 16], n_heads=3).build_model()
+
+
+def test_invalid_n_heads():
+    with pytest.raises(ValueError, match="n_heads must be positive"):
+        _config(n_heads=0).build_model()
+
+
+def test_invalid_dim_feedforward():
+    with pytest.raises(ValueError, match="dim_feedforward must be positive"):
+        _config(dim_feedforward=0).build_model()
+
+
+def test_invalid_n_outputs():
+    with pytest.raises(ValueError, match="n_outputs must be positive"):
+        _config(n_outputs=0).build_model()

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -44,6 +44,7 @@ Beam search and ML
     cayleypy.algo.RandomWalksGenerator
     cayleypy.models.ModelConfig
     cayleypy.models.GroupTokenizer
+    cayleypy.models.TransformerModel
     cayleypy.models.graph_hash
     cayleypy.models.save_checkpoint
     cayleypy.models.load_checkpoint


### PR DESCRIPTION
Adds `TransformerModel` (`model_type="TRANSFORMER"`) — a transformer encoder over tokens produced by `GroupTokenizer` (#4).

**Architecture:** token embedding + learnable positional embedding + token-type embedding (corners vs edges) → `nn.TransformerEncoder` (pre-norm blocks, GELU, no dropout, attention through SDPA) → mean over tokens → linear head with `n_outputs` neurons. With `n_outputs = n_generators` this is a Q-model, which scores all children of a state in one forward pass (`Predictor.score_children`, #1).

**Config:** `layers_sizes` has one entry per encoder layer and all entries must be equal (a transformer encoder keeps the same number of features in all layers), so `[256] * 4` means 4 layers of width 256. Two optional fields are added to `ModelConfig`: `n_heads` (default: one head per 64 features) and `dim_feedforward` (default: 4× model width). `tokenizer_groups` is required; `num_classes_for_one_hot` is not used, because the vocabulary is determined by the tokenizer. A Megaminx example is in the class docstring.

`GroupTokenizer` now imports `ModelConfig` only for type checking — it needs it only in annotations, and at run time it would make `models.py → transformer.py → tokenizer.py → models.py` a circular import.

**Weights:** #11 registers the first model trained with the trainer (#9, #10) in `PREDICTOR_MODELS` and proves the whole path — training, self-describing checkpoint, registry, beam search with one output per generator — works; that demo model is a `ResMlpModel`, because the graph it is trained for is not tokenizable. Weights for this architecture specifically still need either a training run on a puzzle with a tokenizer spec (Megaminx) or a conversion of the donor weights; both are tracked in the series (see the notes on transformer parity).

**Tests:** output shapes for single-output and Q-variants (batch and single state), Megaminx config (tokenizer sizes, vocabulary, number of layers), defaults for heads/feed-forward, independence of the output from batch size, checkpoint round-trip (including `n_heads`/`dim_feedforward` in the config), use as a `Predictor`; errors: no `tokenizer_groups`, groups inconsistent with `input_size`, empty `layers_sizes`, layers of different width, width not divisible by the number of heads, non-positive `n_heads`/`dim_feedforward`/`n_outputs`.

`./lint.sh` and `RUN_SLOW_TESTS=1 pytest` (350 passed) are green on Python 3.12 (torch 2.13) and Python 3.9 (torch 2.8); `docs/build_docs.sh` (`-W`) is green.

Draft until #4 is merged. Base is `feat/group-tokenizer`.



---

Based on #195, which is the base branch of this PR, so this diff is only its own change. #195 should be merged first.
