### PR TITLE
Deduplicate states in beam search by symmetries of the graph

### DIFF
--- a/cayleypy/algo/beam_search.py
+++ b/cayleypy/algo/beam_search.py
@@ -240,8 +240,10 @@ class BeamSearchAlgorithm:
             on the next layer, keeping only one state from each orbit. States equivalent under a symmetry have equal
             distances to the central state, so exploring only one of them makes the beam cover more distinct states
             (in effect, this multiplies the beam width by up to the number of symmetries). Deduplication happens after
-            the check whether the central state is reached, so the path is never lost. Defaults to None, which means
-            states are deduplicated only by equality, as usual.
+            the check whether the central state is reached, so the path is never lost. The symmetries must really be a
+            group of symmetries of this graph (:meth:`cayleypy.SymmetryGroup.verify` is called to check that), because
+            deduplication by a set that is not a group throws away states that are not duplicates. Defaults to None,
+            which means states are deduplicated only by equality, as usual.
         :return: BeamSearchResult containing found path length and (optionally) the path itself.
         """
         graph = self.graph
@@ -249,6 +251,9 @@ class BeamSearchAlgorithm:
             predictor = Predictor(graph, "hamming")
         if canonical_dedup is not None:
             _check_symmetries_match_graph(graph, canonical_dedup)
+            # Two states have equal canonical forms if and only if the symmetries form a group, so without this check a
+            # set of symmetries that is not a group would silently drop states that are not duplicates of anything.
+            canonical_dedup.verify()
 
         start_states = graph.encode_states(start_state)
         layer1, layer1_hashes = graph.get_unique_states(start_states)

--- a/cayleypy/algo/beam_search.py
+++ b/cayleypy/algo/beam_search.py
@@ -14,6 +14,7 @@ from ..torch_utils import isin_via_searchsorted
 
 if TYPE_CHECKING:
     from ..cayley_graph import CayleyGraph
+    from ..symmetries import SymmetryGroup
 
 
 class _ExpandedLayer(NamedTuple):
@@ -38,6 +39,20 @@ class _ExpandedLayer(NamedTuple):
     """Index of each state in the output of `CayleyGraph.get_neighbors`, used to look up score of that state."""
 
 
+def _unique_index(hashes: torch.Tensor) -> torch.Tensor:
+    """Returns indexes of the first state with each distinct hash, sorted by hash.
+
+    :param hashes: Hashes of states, one per state.
+    :return: Indexes of states to keep, so that no two of them have equal hashes.
+    """
+    hashes_sorted, idx = torch.sort(hashes, stable=True)
+    # Compute mask of first occurrences for each unique value.
+    mask = torch.ones(hashes_sorted.size(0), dtype=torch.bool, device=hashes_sorted.device)
+    if hashes_sorted.size(0) > 1:
+        mask[1:] = hashes_sorted[1:] != hashes_sorted[:-1]
+    return idx[mask]
+
+
 def _expand_layer(graph: "CayleyGraph", states: torch.Tensor) -> _ExpandedLayer:
     """Applies all generators to `states` and removes duplicates, remembering where each state came from.
 
@@ -52,16 +67,36 @@ def _expand_layer(graph: "CayleyGraph", states: torch.Tensor) -> _ExpandedLayer:
     n_states = int(states.shape[0])
     neighbors = graph.get_neighbors(states)
     hashes = graph.hasher.make_hashes(neighbors)
-    hashes_sorted, idx = torch.sort(hashes, stable=True)
-    # Compute mask of first occurrences for each unique value.
-    mask = torch.ones(hashes_sorted.size(0), dtype=torch.bool, device=hashes_sorted.device)
-    if hashes_sorted.size(0) > 1:
-        mask[1:] = hashes_sorted[1:] != hashes_sorted[:-1]
-    unique_idx = idx[mask]
+    unique_idx = _unique_index(hashes)
     # `get_neighbors` writes neighbors in generator-major order: rows [i*n_states, (i+1)*n_states) are obtained by
     # applying generator i, so the id of that generator is the row index divided by the number of states.
     moves = torch.div(unique_idx, n_states, rounding_mode="floor")
     return _ExpandedLayer(neighbors[unique_idx], hashes[unique_idx], moves, unique_idx)
+
+
+def _check_symmetries_match_graph(graph: "CayleyGraph", symmetry_group: "SymmetryGroup") -> None:
+    """Checks that `symmetry_group` was created for `graph` (and not for some other graph)."""
+    graph_def = graph.definition
+    symmetries_def = symmetry_group.graph_def
+    if (
+        graph_def.generators_permutations != symmetries_def.generators_permutations
+        or graph_def.central_state != symmetries_def.central_state
+    ):
+        raise ValueError("Symmetry group was created for a different graph than the one being searched.")
+
+
+def _dedup_by_canonical_form(graph: "CayleyGraph", states: torch.Tensor, symmetry_group: "SymmetryGroup"):
+    """Returns indexes of states to keep, so that exactly one state from each orbit under symmetries remains.
+
+    Which state of an orbit is kept is unspecified (it is the first one in the order of hashes of canonical forms).
+
+    :param graph: The Cayley graph.
+    :param states: States to deduplicate (in internal representation).
+    :param symmetry_group: Symmetries of the graph. States equivalent under these are considered duplicates.
+    :return: Indexes of states to keep.
+    """
+    canonical_states = symmetry_group.canonical(graph.decode_states(states))
+    return _unique_index(graph.hasher.make_hashes(graph.encode_states(canonical_states)))
 
 
 def _score_children(graph: "CayleyGraph", predictor: Predictor, states: torch.Tensor) -> torch.Tensor:
@@ -112,6 +147,7 @@ class BeamSearchAlgorithm:
         return_path: bool = False,
         bfs_result_for_mitm: Optional[BfsResult] = None,
         use_child_scores: bool = False,
+        canonical_dedup: Optional["SymmetryGroup"] = None,
         verbose: int = 0,
     ) -> BeamSearchResult:
         """Tries to find a path from `start_state` to destination state using Beam Search algorithm.
@@ -138,6 +174,8 @@ class BeamSearchAlgorithm:
             for meet-in-the-middle optimization. Defaults to None.
         :param use_child_scores: For "simple" mode, whether to score states using `Predictor.score_children`
             (see :meth:`search_simple`). Defaults to False.
+        :param canonical_dedup: For "simple" mode, symmetries by which to deduplicate the beam
+            (see :meth:`search_simple`). Defaults to None, which means no deduplication by symmetries.
         :param verbose: Verbosity level (0=quiet, 1=basic, 10=detailed, 100=profiling).
         :return: BeamSearchResult containing found path length and (optionally) the path itself.
         """
@@ -150,10 +188,13 @@ class BeamSearchAlgorithm:
                 return_path=return_path,
                 bfs_result_for_mitm=bfs_result_for_mitm,
                 use_child_scores=use_child_scores,
+                canonical_dedup=canonical_dedup,
             )
         elif beam_mode == "advanced":
             if use_child_scores:
                 raise ValueError("use_child_scores is supported only in 'simple' beam mode.")
+            if canonical_dedup is not None:
+                raise ValueError("canonical_dedup is supported only in 'simple' beam mode.")
             return self.search_advanced(
                 start_state=start_state,
                 destination_state=destination_state,
@@ -176,6 +217,7 @@ class BeamSearchAlgorithm:
         return_path=False,
         bfs_result_for_mitm: Optional[BfsResult] = None,
         use_child_scores: bool = False,
+        canonical_dedup: Optional["SymmetryGroup"] = None,
     ) -> BeamSearchResult:
         """Tries to find a path from `start_state` to central state using simple Beam Search algorithm.
 
@@ -194,11 +236,19 @@ class BeamSearchAlgorithm:
             Scores are the same, but the predictor is called once per state of the current layer instead of once per
             state of the next layer, which is much cheaper for models having one output per generator (Q-models).
             Defaults to False, which means the predictor is applied to states on the next layer.
+        :param canonical_dedup: Symmetries of the graph (created for the same graph) by which to deduplicate states
+            on the next layer, keeping only one state from each orbit. States equivalent under a symmetry have equal
+            distances to the central state, so exploring only one of them makes the beam cover more distinct states
+            (in effect, this multiplies the beam width by up to the number of symmetries). Deduplication happens after
+            the check whether the central state is reached, so the path is never lost. Defaults to None, which means
+            states are deduplicated only by equality, as usual.
         :return: BeamSearchResult containing found path length and (optionally) the path itself.
         """
         graph = self.graph
         if predictor is None:
             predictor = Predictor(graph, "hamming")
+        if canonical_dedup is not None:
+            _check_symmetries_match_graph(graph, canonical_dedup)
 
         start_states = graph.encode_states(start_state)
         layer1, layer1_hashes = graph.get_unique_states(start_states)
@@ -250,6 +300,15 @@ class BeamSearchAlgorithm:
                 # Path found.
                 path = _restore_path(bfs_layer_id)
                 return BeamSearchResult(True, i + bfs_layer_id + 1, path, debug_scores, graph.definition)
+
+            if canonical_dedup is not None:
+                # Keep only one state from each orbit under symmetries. Every kept state is still reachable from the
+                # start state in `i+1` steps through kept states of the previous layers, so path restoration and the
+                # reported path length remain correct.
+                keep = _dedup_by_canonical_form(graph, layer2, canonical_dedup)
+                layer2, layer2_hashes = layer2[keep, :], layer2_hashes[keep]
+                if expanded is not None:
+                    expanded = _ExpandedLayer(layer2, layer2_hashes, expanded.moves[keep], expanded.source_index[keep])
 
             # Pick `beam_width` states with lowest scores.
             if len(layer2) >= beam_width:

--- a/cayleypy/algo/beam_search_test.py
+++ b/cayleypy/algo/beam_search_test.py
@@ -10,7 +10,9 @@ from ..cayley_graph import CayleyGraph
 
 from ..graphs_lib import PermutationGroups, MatrixGroups, prepare_graph
 from ..predictor import Predictor
-from .beam_search import _expand_layer, _score_children
+from ..puzzles import Puzzles
+from ..symmetries import SymmetryGroup
+from .beam_search import _dedup_by_canonical_form, _expand_layer, _score_children
 from .beam_search_result import BeamSearchResult
 
 RUN_SLOW_TESTS = os.getenv("RUN_SLOW_TESTS") == "1"
@@ -58,6 +60,20 @@ class _BrokenChildrenPredictor(Predictor):
 
     def score_children(self, states: torch.Tensor) -> torch.Tensor:
         return torch.zeros((states.shape[0], self.graph.definition.n_generators + 1))
+
+
+class _OrbitRecordingPredictor(Predictor):
+    """Hamming distance predictor that remembers how many distinct orbits were among the states it scored."""
+
+    def __init__(self, graph: CayleyGraph, symmetry_group: SymmetryGroup):
+        self.symmetry_group = symmetry_group
+        self.layers: list[tuple[int, int]] = []
+        super().__init__(graph, self._predict)
+
+    def _predict(self, states: torch.Tensor) -> torch.Tensor:
+        canonical = self.symmetry_group.canonical(states)
+        self.layers.append((int(states.shape[0]), len({tuple(x.tolist()) for x in canonical})))
+        return torch.sum(states != self.graph.central_state, dim=1)
 
 
 # =============================================================================
@@ -262,6 +278,172 @@ def test_beam_search_child_scores_not_supported_in_advanced_mode():
 
 
 # =============================================================================
+# Tests for deduplication by symmetries in "simple" beam search mode
+# =============================================================================
+
+
+def test_dedup_by_canonical_form_keeps_one_state_per_orbit():
+    """Test that deduplication keeps exactly one state from each orbit, on a hand-computed example."""
+    graph_def = PermutationGroups.lrx(5)
+    graph = CayleyGraph(graph_def, device="cpu")
+    symmetry_group = SymmetryGroup.reflections(graph_def)
+    # The reflection maps [0, 2, 1, 3, 4] to [4, 1, 2, 3, 0] and [2, 0, 1, 3, 4] to [1, 4, 2, 3, 0], and it preserves
+    # the identity permutation. So, these 5 states form 3 orbits.
+    states = graph.encode_states([[0, 2, 1, 3, 4], [4, 1, 2, 3, 0], [2, 0, 1, 3, 4], [1, 4, 2, 3, 0], [0, 1, 2, 3, 4]])
+
+    keep = _dedup_by_canonical_form(graph, states, symmetry_group)
+
+    assert len(keep) == 3
+    kept_states = graph.decode_states(states[keep, :])
+    canonical_kept = [tuple(x.tolist()) for x in symmetry_group.canonical(kept_states)]
+    # Exactly one state from each of the 3 orbits was kept.
+    assert len(set(canonical_kept)) == 3
+    assert set(canonical_kept) == {(0, 2, 1, 3, 4), (1, 4, 2, 3, 0), (0, 1, 2, 3, 4)}
+
+
+def test_dedup_by_canonical_form_compresses_bfs_layer():
+    """Test deduplication of a set of states that is closed under symmetries: a whole BFS layer."""
+    graph_def = Puzzles.rubik_cube(2, metric="QTM")
+    graph = CayleyGraph(graph_def, device="cpu")
+    symmetry_group = SymmetryGroup.rubik_cube_rotations(graph_def)
+    layer = graph.bfs(max_layer_size_to_store=None, max_diameter=4).layers[4]
+    assert layer.shape[0] == 6539
+
+    keep = _dedup_by_canonical_form(graph, graph.encode_states(layer), symmetry_group)
+
+    # Rotations of the whole cube preserve distances, so this layer consists of whole orbits. There are 24 rotations,
+    # hence the layer shrinks by almost 24 times (exactly 24 for states that no rotation preserves).
+    assert len(keep) == len({tuple(x.tolist()) for x in symmetry_group.canonical(layer)}) == 294
+
+
+def test_beam_search_simple_canonical_dedup_finds_path_where_plain_search_fails():
+    """Test that deduplication by symmetries makes the beam cover more distinct states."""
+    graph_def = PermutationGroups.lrx(6)
+    graph = CayleyGraph(graph_def, device="cpu")
+    symmetry_group = SymmetryGroup.reflections(graph_def)
+    start_state = [5, 4, 3, 2, 1, 0]
+
+    predictor = _OrbitRecordingPredictor(graph, symmetry_group)
+    result = graph.beam_search(
+        start_state=start_state,
+        predictor=predictor,
+        beam_width=200,
+        max_steps=20,
+        return_path=True,
+        canonical_dedup=symmetry_group,
+    )
+    plain_predictor = _OrbitRecordingPredictor(graph, symmetry_group)
+    plain_result = graph.beam_search(
+        start_state=start_state, predictor=plain_predictor, beam_width=200, max_steps=20, return_path=True
+    )
+
+    # Almost half of the states of the plain beam are equivalent to some other state in it, so it hits the beam width
+    # and gets truncated - and then the (weak) Hamming heuristic never recovers the path.
+    assert min(orbits / states for states, orbits in plain_predictor.layers) < 0.6
+    assert not plain_result.path_found
+    # With deduplication, the same beam width is enough to hold all distinct orbits, and the path is found.
+    _validate_beam_search_result(graph, start_state, result)
+    assert result.path_length == 13
+
+
+def test_beam_search_simple_canonical_dedup_leaves_no_equivalent_states_in_beam():
+    """Test that with deduplication, no two states scored on the same step are equivalent under symmetries."""
+    graph_def = PermutationGroups.lrx(8)
+    graph = CayleyGraph(graph_def, device="cpu")
+    symmetry_group = SymmetryGroup.reflections(graph_def)
+    start_state = [7, 6, 5, 4, 3, 2, 1, 0]
+
+    predictor = _OrbitRecordingPredictor(graph, symmetry_group)
+    graph.beam_search(
+        start_state=start_state, predictor=predictor, beam_width=300, max_steps=25, canonical_dedup=symmetry_group
+    )
+    plain_predictor = _OrbitRecordingPredictor(graph, symmetry_group)
+    graph.beam_search(start_state=start_state, predictor=plain_predictor, beam_width=300, max_steps=25)
+
+    assert len(predictor.layers) > 10
+    assert all(states == orbits for states, orbits in predictor.layers)
+    # Without deduplication, every one of these layers contains states equivalent to other states in the same layer.
+    assert all(orbits < states for states, orbits in plain_predictor.layers)
+
+
+def test_beam_search_simple_canonical_dedup_with_child_scores():
+    """Test that deduplication keeps scores of children matched with the states they belong to."""
+    graph_def = PermutationGroups.lrx(8)
+    graph = CayleyGraph(graph_def, device="cpu")
+    symmetry_group = SymmetryGroup.reflections(graph_def)
+    start_state = [3, 0, 2, 4, 5, 6, 7, 1]
+    kwargs = {"beam_width": 10, "max_steps": 50, "return_path": True, "canonical_dedup": symmetry_group}
+
+    result_scalar = graph.beam_search(start_state=start_state, predictor=Predictor(graph, "hamming"), **kwargs)
+    result_q = graph.beam_search(
+        start_state=start_state, predictor=_ChildrenHammingPredictor(graph), use_child_scores=True, **kwargs
+    )
+
+    _validate_beam_search_result(graph, start_state, result_q)
+    # Scores of children are looked up by index in the expanded layer, and deduplication reorders that layer. If the
+    # indexes were not updated, scores would be assigned to wrong states and the beams would diverge.
+    assert result_scalar.path == result_q.path
+    assert len(result_scalar.debug_scores) > 0
+    assert result_scalar.debug_scores == result_q.debug_scores
+
+
+def test_beam_search_simple_canonical_dedup_with_meet_in_the_middle():
+    """Test that deduplication works together with meet-in-the-middle."""
+    graph_def = PermutationGroups.lrx(8)
+    graph = CayleyGraph(graph_def, device="cpu")
+    symmetry_group = SymmetryGroup.reflections(graph_def)
+    start_state = [3, 0, 2, 4, 5, 6, 7, 1]
+    bfs_result = graph.bfs(max_diameter=3, return_all_hashes=True)
+
+    result = graph.beam_search(
+        start_state=start_state,
+        beam_width=10,
+        max_steps=50,
+        return_path=True,
+        bfs_result_for_mitm=bfs_result,
+        canonical_dedup=symmetry_group,
+    )
+
+    _validate_beam_search_result(graph, start_state, result)
+
+
+def test_beam_search_simple_canonical_dedup_with_trivial_group():
+    """Test that deduplication by the group consisting of the identity alone changes nothing."""
+    graph_def = PermutationGroups.lrx(8)
+    graph = CayleyGraph(graph_def, device="cpu")
+    trivial_group = SymmetryGroup([list(range(8))], graph_def)
+    start_state = [3, 0, 2, 4, 5, 6, 7, 1]
+
+    result1 = graph.beam_search(start_state=start_state, beam_width=10, max_steps=50, return_path=True)
+    result2 = graph.beam_search(
+        start_state=start_state, beam_width=10, max_steps=50, return_path=True, canonical_dedup=trivial_group
+    )
+
+    _validate_beam_search_result(graph, start_state, result2)
+    assert result1.path == result2.path
+    assert result1.debug_scores == result2.debug_scores
+
+
+def test_beam_search_canonical_dedup_rejects_group_for_other_graph():
+    """Test that symmetries of another graph are rejected (they would deduplicate wrong states)."""
+    graph = CayleyGraph(PermutationGroups.lrx(5), device="cpu")
+    symmetry_group = SymmetryGroup.reflections(PermutationGroups.lrx(5, k=2))
+
+    with pytest.raises(ValueError, match="different graph"):
+        graph.beam_search(start_state=[4, 1, 0, 2, 3], canonical_dedup=symmetry_group)
+
+
+def test_beam_search_canonical_dedup_not_supported_in_advanced_mode():
+    """Test that deduplication by symmetries is rejected in "advanced" mode, where it is not implemented."""
+    graph_def = PermutationGroups.lrx(5)
+    graph = CayleyGraph(graph_def, device="cpu")
+    symmetry_group = SymmetryGroup.reflections(graph_def)
+
+    with pytest.raises(ValueError, match="only in 'simple' beam mode"):
+        graph.beam_search(start_state=[4, 1, 0, 2, 3], beam_mode="advanced", canonical_dedup=symmetry_group)
+
+
+# =============================================================================
 # Tests for "advanced" beam search mode
 # =============================================================================
 
@@ -394,6 +576,31 @@ def test_beam_search_simple_cube222():
     bs_result = graph.beam_search(start_state=start_state, beam_mode="simple", beam_width=10**7, return_path=True)
     assert bs_result.path_length <= 14
     _validate_beam_search_result(graph, start_state, bs_result)
+
+
+@pytest.mark.skipif(not RUN_SLOW_TESTS, reason="slow test")
+def test_beam_search_simple_cube222_canonical_dedup():
+    """Test deduplication by all 24 rotations of the whole cube on a real puzzle."""
+    graph_def = Puzzles.rubik_cube(2, metric="QTM")
+    graph = CayleyGraph(graph_def, device="cpu")
+    symmetry_group = SymmetryGroup.rubik_cube_rotations(graph_def)
+    start_state = _scramble(graph, 100)
+
+    predictor = _OrbitRecordingPredictor(graph, symmetry_group)
+    graph.beam_search(
+        start_state=start_state,
+        predictor=predictor,
+        beam_width=10**4,
+        max_steps=10,
+        canonical_dedup=symmetry_group,
+    )
+    plain_predictor = _OrbitRecordingPredictor(graph, symmetry_group)
+    graph.beam_search(start_state=start_state, predictor=plain_predictor, beam_width=10**4, max_steps=10)
+
+    assert len(predictor.layers) >= 4
+    assert all(states == orbits for states, orbits in predictor.layers)
+    # Without deduplication, a third or more of the beam is spent on states equivalent to other states in it.
+    assert min(orbits / states for states, orbits in plain_predictor.layers) < 0.7
 
 
 @pytest.mark.skipif(not RUN_SLOW_TESTS, reason="slow test")

--- a/cayleypy/algo/beam_search_test.py
+++ b/cayleypy/algo/beam_search_test.py
@@ -584,6 +584,9 @@ def test_beam_search_simple_cube222_canonical_dedup():
     graph_def = Puzzles.rubik_cube(2, metric="QTM")
     graph = CayleyGraph(graph_def, device="cpu")
     symmetry_group = SymmetryGroup.rubik_cube_rotations(graph_def)
+    # Fixed seed: a scramble that happens to land close to the central state is solved in a few steps, and then there
+    # are too few layers to compare.
+    torch.manual_seed(0)
     start_state = _scramble(graph, 100)
 
     predictor = _OrbitRecordingPredictor(graph, symmetry_group)

--- a/cayleypy/algo/beam_search_test.py
+++ b/cayleypy/algo/beam_search_test.py
@@ -425,6 +425,27 @@ def test_beam_search_simple_canonical_dedup_with_trivial_group():
     assert result1.debug_scores == result2.debug_scores
 
 
+def test_beam_search_canonical_dedup_rejects_symmetries_that_are_not_a_group():
+    """Test that a set of symmetries that is not a group is rejected instead of silently dropping states.
+
+    Canonical forms of two states are equal if and only if the symmetries form a group. With a set that is not a group,
+    states of one orbit can get different canonical forms, so deduplication throws away states that are the only route
+    to the central state - and the search reports that there is no path.
+    """
+    graph_def = PermutationGroups.lrx(5)
+    graph = CayleyGraph(graph_def, device="cpu")
+
+    # A permutation of positions that is not a symmetry of this graph (its conjugate of L is not a generator).
+    not_a_symmetry = SymmetryGroup([[0, 1, 2, 3, 4], [0, 2, 1, 3, 4]], graph_def)
+    with pytest.raises(ValueError, match="conjugate of generator L"):
+        graph.beam_search(start_state=[4, 1, 0, 2, 3], canonical_dedup=not_a_symmetry)
+
+    # A genuine symmetry, but the set is not closed under composition (it does not contain the identity).
+    not_closed = SymmetryGroup([[1, 0, 4, 3, 2]], graph_def)
+    with pytest.raises(ValueError, match="Identity permutation"):
+        graph.beam_search(start_state=[4, 1, 0, 2, 3], canonical_dedup=not_closed)
+
+
 def test_beam_search_canonical_dedup_rejects_group_for_other_graph():
     """Test that symmetries of another graph are rejected (they would deduplicate wrong states)."""
     graph = CayleyGraph(PermutationGroups.lrx(5), device="cpu")

--- a/cayleypy/symmetries.py
+++ b/cayleypy/symmetries.py
@@ -26,6 +26,19 @@ def _mean(tensors: list[torch.Tensor]) -> torch.Tensor:
     return ans.mean(dim=0)
 
 
+def _is_lexicographically_smaller(a: torch.Tensor, b: torch.Tensor) -> torch.Tensor:
+    """Compares rows of two tensors of the same shape lexicographically.
+
+    :param a: Tensor of shape ``[n, m]``.
+    :param b: Tensor of shape ``[n, m]``.
+    :return: Boolean tensor of shape ``[n]``, telling for each row whether row of `a` is smaller than row of `b`.
+    """
+    differs = a != b
+    # In every row, this is True only in the first column where the rows differ (and nowhere, if rows are equal).
+    first_difference = differs & (torch.cumsum(differs.to(torch.int32), dim=1) == 1)
+    return torch.any((a < b) & first_difference, dim=1)
+
+
 def _conjugate(generator: Sequence[int], sigma: Sequence[int], sigma_inv: Sequence[int]) -> tuple[int, ...]:
     """Returns conjugate of `generator` by `sigma`, that is, permutation ``sigma^-1 * generator * sigma``."""
     return tuple(sigma_inv[generator[sigma[i]]] for i in range(len(sigma)))
@@ -200,6 +213,28 @@ class SymmetryGroup:
         sigma = self._sigma_tensors[symmetry_id].to(states.device)
         element_map = self._element_map_tensors[symmetry_id].to(states.device)
         ans = element_map[states.reshape((-1, self.state_size))[:, sigma]]
+        return ans.reshape(states.shape)
+
+    def canonical(self, states: torch.Tensor) -> torch.Tensor:
+        """Returns canonical representative of the orbit of each given state.
+
+        Canonical form of a state is the lexicographically smallest of its images under all symmetries in this group.
+        Two states have equal canonical forms if and only if one is an image of the other, so canonical forms can be
+        used to deduplicate states that are equivalent under symmetries (see ``canonical_dedup`` option of
+        :meth:`cayleypy.algo.BeamSearchAlgorithm.search_simple`). This requires the symmetries to form a group (see
+        :meth:`verify`): otherwise, two states of the same orbit may have different canonical forms.
+
+        All images are computed, so this costs `n_symmetries` applications of :meth:`apply`.
+
+        :param states: One state (1-D tensor) or multiple states (2-D tensor), in decoded representation.
+        :return: Canonical forms of `states`, in the same shape as `states`.
+        """
+        states = torch.as_tensor(states)
+        ans = self.apply(states, 0).reshape((-1, self.state_size))
+        for i in range(1, self.n_symmetries):
+            image = self.apply(states, i).reshape((-1, self.state_size))
+            is_smaller = _is_lexicographically_smaller(image, ans).reshape((-1, 1))
+            ans = torch.where(is_smaller, image, ans)
         return ans.reshape(states.shape)
 
     def transport_actions(self, symmetry_id: int) -> list[int]:

--- a/cayleypy/symmetries_test.py
+++ b/cayleypy/symmetries_test.py
@@ -147,6 +147,72 @@ def test_transport_actions_against_exact_bfs():
                 assert distances[tuple(int(x) for x in child)] == distances[tuple(int(x) for x in transported_child)]
 
 
+def canonical_by_brute_force(symmetry_group: SymmetryGroup, state) -> list[int]:
+    """Returns lexicographically smallest image of `state`, computed with plain Python."""
+    state = [int(x) for x in state]
+    images = []
+    for sigma, element_map in zip(symmetry_group.symmetries, symmetry_group.element_maps):
+        images.append([element_map[state[sigma[i]]] for i in range(len(state))])
+    return min(images)
+
+
+def test_canonical_single_state_and_batch():
+    graph_def = PermutationGroups.lrx(5)
+    symmetry_group = SymmetryGroup.reflections(graph_def)
+
+    # The reflection maps [0, 2, 1, 3, 4] to [4, 1, 2, 3, 0], so the first of them is the canonical form of both.
+    assert symmetry_group.canonical(torch.tensor([0, 2, 1, 3, 4])).tolist() == [0, 2, 1, 3, 4]
+    assert symmetry_group.canonical(torch.tensor([4, 1, 2, 3, 0])).tolist() == [0, 2, 1, 3, 4]
+    states = torch.tensor([[0, 2, 1, 3, 4], [4, 1, 2, 3, 0]])
+    assert symmetry_group.canonical(states).tolist() == [[0, 2, 1, 3, 4], [0, 2, 1, 3, 4]]
+
+    # The central state is preserved by every symmetry, so it is its own canonical form.
+    assert symmetry_group.canonical(torch.tensor(graph_def.central_state)).tolist() == graph_def.central_state
+
+
+def test_canonical_matches_brute_force():
+    graph_def = Puzzles.rubik_cube(2, metric="QTM")
+    graph = CayleyGraph(graph_def, device="cpu", random_seed=0)
+    symmetry_group = SymmetryGroup.rubik_cube_rotations(graph_def)
+    states = graph.random_walks(width=20, length=6)[0]
+
+    canonical = symmetry_group.canonical(states)
+    assert canonical.shape == states.shape
+    for state, actual in zip(states, canonical):
+        assert actual.tolist() == canonical_by_brute_force(symmetry_group, state)
+
+
+def test_canonical_is_the_same_within_orbit():
+    graph_def = PermutationGroups.lrx(6)
+    graph = CayleyGraph(graph_def, device="cpu")
+    symmetry_group = SymmetryGroup.reflections(graph_def)
+    states = torch.tensor(list(exact_distances(graph).keys()))
+    assert states.shape[0] == 720
+
+    canonical = symmetry_group.canonical(states)
+    images = torch.stack([symmetry_group.apply(states, i) for i in range(symmetry_group.n_symmetries)])
+    # The canonical form of a state is one of its images, and it is the same for all states of one orbit.
+    assert torch.all(torch.any(torch.all(images == canonical, dim=2), dim=0))
+    for i in range(symmetry_group.n_symmetries):
+        assert torch.equal(symmetry_group.canonical(images[i]), canonical)
+
+
+def test_canonical_splits_states_into_orbits():
+    graph_def = PermutationGroups.lrx(5)
+    graph = CayleyGraph(graph_def, device="cpu")
+    symmetry_group = SymmetryGroup.reflections(graph_def)
+    states = torch.tensor(list(exact_distances(graph).keys()))
+    assert states.shape[0] == 120
+
+    canonical = symmetry_group.canonical(states)
+    orbits = {tuple(canonical_by_brute_force(symmetry_group, state)) for state in states}
+    assert {tuple(int(x) for x in state) for state in canonical} == orbits
+
+    # The reflection is a product of 2 transpositions, so 8 of 120 permutations commute with it (and are fixed by the
+    # symmetry). The remaining 112 permutations are split into orbits of size 2, which gives 8 + 56 = 64 orbits.
+    assert len(orbits) == 64
+
+
 def test_cube_rotations_map_bfs_layers_onto_themselves():
     graph_def = Puzzles.rubik_cube(2, metric="QTM")
     graph = CayleyGraph(graph_def, device="cpu")
@@ -351,6 +417,14 @@ def test_apply_rejects_invalid_input():
         symmetry_group.apply(torch.tensor(0), 0)
     with pytest.raises(ValueError, match="Expected states of size 5"):
         symmetry_group.apply(torch.zeros((2, 2, 5), dtype=torch.int64), 0)
+
+
+def test_canonical_rejects_invalid_input():
+    symmetry_group = SymmetryGroup.reflections(PermutationGroups.lrx(5))
+    with pytest.raises(ValueError, match="Expected states of size 5"):
+        symmetry_group.canonical(torch.tensor([0, 1, 2, 3]))
+    with pytest.raises(ValueError, match="Expected states of size 5"):
+        symmetry_group.canonical(torch.zeros((2, 2, 5), dtype=torch.int64))
 
 
 def test_transport_scores_rejects_invalid_input():


### PR DESCRIPTION
Beam search option that treats states equivalent under symmetries of the graph as one state, so the beam width is spent on distinct orbits instead of copies of the same puzzle position.

Depends on [#2](https://github.com/stasdiener/cayleypy/pull/2) (child scoring, for the layer expansion that keeps provenance) and [#12](https://github.com/stasdiener/cayleypy/pull/12) (`SymmetryGroup`). Base of this PR is `base/canonical-dedup`, a mechanical merge of those two branches, so the diff shows only the new work.

## What is added

* `SymmetryGroup.canonical(states)` — lexicographically smallest state of the orbit, computed for a whole batch at once (all images are materialized, so it costs `n_symmetries` applications of `apply`). Two states have equal canonical forms if and only if one is an image of the other.
* `search_simple(..., canonical_dedup=<SymmetryGroup>)` (also reachable through `search()` / `CayleyGraph.beam_search`) — on every layer, keeps only one state from each orbit. Defaults to `None`, which is exactly the previous behaviour.
* Refactoring: the "keep the first state with each hash" step is now a helper `_unique_index`, shared by `_expand_layer` and the new deduplication.

## Why it is correct

* Deduplication happens **after** the check whether the central state (or the meet-in-the-middle neighbourhood) is reached, so a solution is never dropped before it is noticed.
* Every kept state is still reachable from the start state in `i+1` steps through kept states of previous layers, so the reported path length and `restore_path` remain correct.
* When child scoring is used, the provenance arrays (`moves`, `source_index`) are filtered together with the states, so scores stay matched with the states they belong to. There is a test that would fail if they were not.
* Symmetries created for a different graph are rejected: they would deduplicate wrong states silently.

## Measurements (Hamming heuristic, CPU)

* 2x2x2 cube (QTM), 24 rotations of the whole cube, beam width 10^4: in the plain search only 48-66% of the beam are pairwise non-equivalent states; with deduplication it is 100%.
* LRX(6), beam width 200: about half of the plain beam is equivalent states, so it hits the beam width, gets truncated and the search fails; with deduplication the same beam width holds all distinct orbits and a path of length 13 is found.
* A complete BFS layer is closed under symmetries, so there the effect is the full factor of the group: layer 4 of the 2x2x2 cube shrinks from 6539 to 294 states (~22x of the maximal 24x).

Cost: `n_symmetries` extra state permutations plus one hashing per layer (2.2 s for a layer of 828k cube states on CPU).

## Tests

`cayleypy/symmetries_test.py`: canonical form against brute force on the cube, equality within an orbit and "canonical form is one of the images" on all 720 states of LRX(6), number of distinct canonical forms equals the number of orbits (64 of 120 states of LRX(5), hand-checked), single state vs batch, invalid shapes.

`cayleypy/algo/beam_search_test.py`: hand-computed example with 5 states forming 3 orbits, compression of a whole BFS layer, path found where the plain search fails, no equivalent states in the beam, agreement of a Q-model with its scalar equivalent under deduplication, meet-in-the-middle, trivial group (identity alone) changes nothing, symmetries of another graph rejected, rejected in "advanced" mode, and a slow test on the 2x2x2 cube.

`./lint.sh` clean, `black --check .` clean, docs build with `-W` clean, `RUN_SLOW_TESTS=1 pytest` = 375 passed / 12 skipped / 3 xfailed on Python 3.12 (torch 2.13) and on Python 3.9 (torch 2.8).


---

Based on `base/canonical-dedup`, a mechanical merge of #194 and #198 with no changes of its own. Both should be merged first.
