### PR TITLE
Add non-backtracking option to simple beam search

### DIFF
--- a/cayleypy/algo/beam_search.py
+++ b/cayleypy/algo/beam_search.py
@@ -365,8 +365,6 @@ class BeamSearchAlgorithm:
                 if expanded is not None:
                     expanded = _ExpandedLayer(layer2, layer2_hashes, expanded.moves[keep], expanded.source_index[keep])
 
-            layer2_moves = expanded.moves if expanded is not None else None
-
             # Pick `beam_width` states with lowest scores.
             if len(layer2) >= beam_width:
                 if expanded is not None and use_child_scores:
@@ -374,11 +372,11 @@ class BeamSearchAlgorithm:
                 else:
                     scores = predictor(graph.decode_states(layer2))
                 idx = torch.argsort(scores)[:beam_width]
-                layer2 = layer2[idx, :]
-                layer2_hashes = layer2_hashes[idx]
-                if layer2_moves is not None:
-                    layer2_moves = layer2_moves[idx]
                 best_score = float(scores[idx[0]].detach())
+                # Provenance is reordered along with the states, so it keeps describing the states next to it.
+                layer2, layer2_hashes = layer2[idx, :], layer2_hashes[idx]
+                if expanded is not None:
+                    expanded = _ExpandedLayer(layer2, layer2_hashes, expanded.moves[idx], expanded.source_index[idx])
                 debug_scores[i] = best_score
                 if graph.verbose >= 2:
                     print(f"Iteration {i}, best score {best_score}.")
@@ -386,8 +384,8 @@ class BeamSearchAlgorithm:
             layer1 = layer2
             layer1_hashes = layer2_hashes
             if non_backtracking:
-                assert inverse_generators is not None and layer2_moves is not None
-                banned_moves = inverse_generators[layer2_moves]
+                assert inverse_generators is not None and expanded is not None
+                banned_moves = inverse_generators[expanded.moves]
             if return_path:
                 all_layers_hashes.append(layer1_hashes)
 

--- a/cayleypy/algo/beam_search.py
+++ b/cayleypy/algo/beam_search.py
@@ -53,7 +53,9 @@ def _unique_index(hashes: torch.Tensor) -> torch.Tensor:
     return idx[mask]
 
 
-def _expand_layer(graph: "CayleyGraph", states: torch.Tensor) -> _ExpandedLayer:
+def _expand_layer(
+    graph: "CayleyGraph", states: torch.Tensor, banned_moves: Optional[torch.Tensor] = None
+) -> _ExpandedLayer:
     """Applies all generators to `states` and removes duplicates, remembering where each state came from.
 
     This is a variant of `CayleyGraph.get_unique_states` that additionally keeps the link between a state on the next
@@ -62,16 +64,40 @@ def _expand_layer(graph: "CayleyGraph", states: torch.Tensor) -> _ExpandedLayer:
 
     :param graph: The Cayley graph.
     :param states: States of the current layer (in internal representation).
+    :param banned_moves: Id of one generator per state, which must not be applied to that state. Banned moves are
+        excluded before deduplication, so a state that is also produced by some allowed move is still returned.
+        Defaults to None, which means all generators are applied to all states.
     :return: States of the next layer, with provenance of each state.
     """
     n_states = int(states.shape[0])
     neighbors = graph.get_neighbors(states)
     hashes = graph.hasher.make_hashes(neighbors)
-    unique_idx = _unique_index(hashes)
     # `get_neighbors` writes neighbors in generator-major order: rows [i*n_states, (i+1)*n_states) are obtained by
     # applying generator i, so the id of that generator is the row index divided by the number of states.
+    if banned_moves is None:
+        unique_idx = _unique_index(hashes)
+    else:
+        allowed = torch.ones((graph.definition.n_generators, n_states), dtype=torch.bool, device=states.device)
+        allowed[banned_moves, torch.arange(n_states, device=states.device)] = False
+        allowed_idx = allowed.reshape(-1).nonzero().reshape(-1)
+        unique_idx = allowed_idx[_unique_index(hashes[allowed_idx])]
     moves = torch.div(unique_idx, n_states, rounding_mode="floor")
     return _ExpandedLayer(neighbors[unique_idx], hashes[unique_idx], moves, unique_idx)
+
+
+def _inverse_generators(graph: "CayleyGraph") -> torch.Tensor:
+    """Returns id of the inverse generator for each generator, as a tensor indexed by generator id.
+
+    :param graph: The Cayley graph.
+    :return: Tensor of shape `[n_generators]`, where element i is id of the generator inverse to generator i.
+    """
+    inverse_map = graph.definition.generators_inverse_map
+    if inverse_map is None:
+        raise ValueError(
+            "non_backtracking requires inverse-closed generators (for every generator, its inverse must also be a "
+            "generator), which is not the case for this graph."
+        )
+    return torch.tensor(inverse_map, dtype=torch.int64, device=graph.device)
 
 
 def _check_symmetries_match_graph(graph: "CayleyGraph", symmetry_group: "SymmetryGroup") -> None:
@@ -148,6 +174,7 @@ class BeamSearchAlgorithm:
         bfs_result_for_mitm: Optional[BfsResult] = None,
         use_child_scores: bool = False,
         canonical_dedup: Optional["SymmetryGroup"] = None,
+        non_backtracking: bool = False,
         verbose: int = 0,
     ) -> BeamSearchResult:
         """Tries to find a path from `start_state` to destination state using Beam Search algorithm.
@@ -176,6 +203,8 @@ class BeamSearchAlgorithm:
             (see :meth:`search_simple`). Defaults to False.
         :param canonical_dedup: For "simple" mode, symmetries by which to deduplicate the beam
             (see :meth:`search_simple`). Defaults to None, which means no deduplication by symmetries.
+        :param non_backtracking: For "simple" mode, whether to ban moves undoing the previous move
+            (see :meth:`search_simple`). In "advanced" mode, use `history_depth` instead. Defaults to False.
         :param verbose: Verbosity level (0=quiet, 1=basic, 10=detailed, 100=profiling).
         :return: BeamSearchResult containing found path length and (optionally) the path itself.
         """
@@ -189,12 +218,15 @@ class BeamSearchAlgorithm:
                 bfs_result_for_mitm=bfs_result_for_mitm,
                 use_child_scores=use_child_scores,
                 canonical_dedup=canonical_dedup,
+                non_backtracking=non_backtracking,
             )
         elif beam_mode == "advanced":
             if use_child_scores:
                 raise ValueError("use_child_scores is supported only in 'simple' beam mode.")
             if canonical_dedup is not None:
                 raise ValueError("canonical_dedup is supported only in 'simple' beam mode.")
+            if non_backtracking:
+                raise ValueError("non_backtracking is supported only in 'simple' beam mode, use history_depth here.")
             return self.search_advanced(
                 start_state=start_state,
                 destination_state=destination_state,
@@ -218,6 +250,7 @@ class BeamSearchAlgorithm:
         bfs_result_for_mitm: Optional[BfsResult] = None,
         use_child_scores: bool = False,
         canonical_dedup: Optional["SymmetryGroup"] = None,
+        non_backtracking: bool = False,
     ) -> BeamSearchResult:
         """Tries to find a path from `start_state` to central state using simple Beam Search algorithm.
 
@@ -242,6 +275,13 @@ class BeamSearchAlgorithm:
             (in effect, this multiplies the beam width by up to the number of symmetries). Deduplication happens after
             the check whether the central state is reached, so the path is never lost. Defaults to None, which means
             states are deduplicated only by equality, as usual.
+        :param non_backtracking: Whether to ban the move inverse to the move by which a state was reached. Such a move
+            leads back to a state on the previous layer, so banning it makes the beam cover more distinct states. This
+            is similar to `history_depth=1` in "advanced" mode, but it needs no memory to store hashes of the previous
+            layer. A state is banned only along the recorded move: if it is also produced by another move (from
+            another state of the beam), it stays. This pays off when the beam is narrow enough to be truncated; for a
+            beam wide enough to hold the whole layer, banning only removes states from it. Requires the generators to
+            be inverse-closed. Defaults to False.
         :return: BeamSearchResult containing found path length and (optionally) the path itself.
         """
         graph = self.graph
@@ -249,6 +289,7 @@ class BeamSearchAlgorithm:
             predictor = Predictor(graph, "hamming")
         if canonical_dedup is not None:
             _check_symmetries_match_graph(graph, canonical_dedup)
+        inverse_generators = _inverse_generators(graph) if non_backtracking else None
 
         start_states = graph.encode_states(start_state)
         layer1, layer1_hashes = graph.get_unique_states(start_states)
@@ -286,14 +327,23 @@ class BeamSearchAlgorithm:
             assert path2 is not None
             return path1 + path2
 
+        # Moves banned on the current layer (one per state), None if nothing is banned.
+        banned_moves: Optional[torch.Tensor] = None
+        # When children are scored through their parents, or when moves undoing the previous move are banned, we need to
+        # know which (state, generator) pair produced each state of the next layer.
+        need_provenance = use_child_scores or non_backtracking
+
         for i in range(max_steps):
-            # Create states on the next layer. When children are scored through their parents, we additionally need to
-            # know which (state, generator) pair produced each state of the next layer.
-            expanded = _expand_layer(graph, layer1) if use_child_scores else None
+            # Create states on the next layer.
+            expanded = _expand_layer(graph, layer1, banned_moves) if need_provenance else None
             if expanded is not None:
                 layer2, layer2_hashes = expanded.states, expanded.hashes
             else:
                 layer2, layer2_hashes = graph.get_unique_states(graph.get_neighbors(layer1))
+
+            if layer2.shape[0] == 0:
+                # Can happen only with non_backtracking: the only move from every state of the beam was banned.
+                return BeamSearchResult(False, 0, None, debug_scores, graph.definition)
 
             bfs_layer_id = _check_path_found(layer2_hashes)
             if bfs_layer_id != -1:
@@ -310,15 +360,19 @@ class BeamSearchAlgorithm:
                 if expanded is not None:
                     expanded = _ExpandedLayer(layer2, layer2_hashes, expanded.moves[keep], expanded.source_index[keep])
 
+            layer2_moves = expanded.moves if expanded is not None else None
+
             # Pick `beam_width` states with lowest scores.
             if len(layer2) >= beam_width:
-                if expanded is not None:
+                if expanded is not None and use_child_scores:
                     scores = _score_children(graph, predictor, layer1)[expanded.source_index]
                 else:
                     scores = predictor(graph.decode_states(layer2))
                 idx = torch.argsort(scores)[:beam_width]
                 layer2 = layer2[idx, :]
                 layer2_hashes = layer2_hashes[idx]
+                if layer2_moves is not None:
+                    layer2_moves = layer2_moves[idx]
                 best_score = float(scores[idx[0]].detach())
                 debug_scores[i] = best_score
                 if graph.verbose >= 2:
@@ -326,6 +380,9 @@ class BeamSearchAlgorithm:
 
             layer1 = layer2
             layer1_hashes = layer2_hashes
+            if non_backtracking:
+                assert inverse_generators is not None and layer2_moves is not None
+                banned_moves = inverse_generators[layer2_moves]
             if return_path:
                 all_layers_hashes.append(layer1_hashes)
 

--- a/cayleypy/algo/beam_search_test.py
+++ b/cayleypy/algo/beam_search_test.py
@@ -1,5 +1,6 @@
 """Tests for beam search algorithm."""
 
+import itertools
 import os
 
 import numpy as np
@@ -7,7 +8,7 @@ import pytest
 import torch
 
 from ..cayley_graph import CayleyGraph
-
+from ..cayley_graph_def import CayleyGraphDef
 from ..graphs_lib import PermutationGroups, MatrixGroups, prepare_graph
 from ..predictor import Predictor
 from ..puzzles import Puzzles
@@ -441,6 +442,237 @@ def test_beam_search_canonical_dedup_not_supported_in_advanced_mode():
 
     with pytest.raises(ValueError, match="only in 'simple' beam mode"):
         graph.beam_search(start_state=[4, 1, 0, 2, 3], beam_mode="advanced", canonical_dedup=symmetry_group)
+
+
+# =============================================================================
+# Tests for non-backtracking in "simple" beam search mode
+# =============================================================================
+
+
+def _expand_with_non_backtracking(graph: CayleyGraph, states: torch.Tensor):
+    """Expands `states` once without bans, then expands the result banning moves undoing the previous move."""
+    inverse_map = graph.definition.generators_inverse_map
+    assert inverse_map is not None
+    layer1 = _expand_layer(graph, states)
+    banned_moves = torch.tensor(inverse_map)[layer1.moves]
+    return layer1, _expand_layer(graph, layer1.states), _expand_layer(graph, layer1.states, banned_moves)
+
+
+def test_expand_layer_bans_moves():
+    """Test that banned generators are not applied, and provenance of the remaining states stays correct."""
+    graph = CayleyGraph(PermutationGroups.lrx(5), device="cpu")
+    parents = [[0, 1, 2, 3, 4], [1, 0, 2, 3, 4], [2, 3, 4, 0, 1]]
+    banned_moves = [0, 1, 2]
+
+    expanded = _expand_layer(graph, graph.encode_states(parents), torch.tensor(banned_moves))
+
+    expected = {
+        tuple(graph.apply_path(parents[p], [g]).reshape((-1)).tolist())
+        for p in range(len(parents))
+        for g in range(3)
+        if g != banned_moves[p]
+    }
+    assert {tuple(x) for x in graph.decode_states(expanded.states).tolist()} == expected
+    assert len(expanded.states) == len(expected)
+    for i in range(len(expanded.states)):
+        parent_id = int(expanded.source_index[i]) % len(parents)
+        assert int(expanded.moves[i]) != banned_moves[parent_id]
+
+
+def test_expand_layer_keeps_state_reachable_by_allowed_move():
+    """Test that a state is banned only along the banned move, and survives if another move also produces it."""
+    graph = CayleyGraph(PermutationGroups.lrx(5), device="cpu")
+    # X applied to the first state and L applied to the second state both give [1, 0, 2, 3, 4].
+    parents = graph.encode_states([[0, 1, 2, 3, 4], [4, 1, 0, 2, 3]])
+
+    expanded = _expand_layer(graph, parents, torch.tensor([2, 2]))
+
+    states = [tuple(x) for x in graph.decode_states(expanded.states).tolist()]
+    # [1, 0, 2, 3, 4] is still there, produced by generator 0 (L) from the second state (index 1 in the layer).
+    assert (1, 0, 2, 3, 4) in states
+    i = states.index((1, 0, 2, 3, 4))
+    assert int(expanded.moves[i]) == 0
+    assert int(expanded.source_index[i]) == 1
+    # [1, 4, 0, 2, 3] was produced only by the banned move (X applied to the second state), so it is gone.
+    assert (1, 4, 0, 2, 3) not in states
+    assert (1, 4, 0, 2, 3) in [tuple(x) for x in graph.decode_states(_expand_layer(graph, parents).states).tolist()]
+
+
+def test_expand_layer_banned_moves_remove_previous_layer():
+    """Test that the states removed by banning are exactly the states of the previous layer."""
+    graph = CayleyGraph(PermutationGroups.lrx(5), device="cpu")
+    start_state = (0, 1, 2, 3, 4)
+
+    _, plain, non_backtracking = _expand_with_non_backtracking(graph, graph.encode_states(list(start_state)))
+
+    plain_states = {tuple(x) for x in graph.decode_states(plain.states).tolist()}
+    nbt_states = {tuple(x) for x in graph.decode_states(non_backtracking.states).tolist()}
+    # Undoing the move that produced a state leads exactly to the state it was produced from.
+    assert plain_states - nbt_states == {start_state}
+
+
+def test_expand_layer_banned_moves_with_involutions():
+    """Test banning when every generator is its own inverse, so the banned move is the move itself."""
+    graph_def = PermutationGroups.cyclic_coxeter(5)
+    graph = CayleyGraph(graph_def, device="cpu")
+    assert graph_def.generators_inverse_map == [0, 1, 2, 3, 4]
+    start_state = (0, 1, 2, 3, 4)
+
+    layer1, plain, non_backtracking = _expand_with_non_backtracking(graph, graph.encode_states(list(start_state)))
+
+    assert len(layer1.states) == 5
+    # Applying the same transposition twice returns to the start state, and only that state is banned.
+    assert len(plain.states) == 16 and len(non_backtracking.states) == 15
+    assert start_state not in {tuple(x) for x in graph.decode_states(non_backtracking.states).tolist()}
+
+
+def test_beam_search_simple_non_backtracking_solves_more_states():
+    """Test that with a narrow beam, banning moves that undo the previous move solves much more states."""
+    n = 5
+    graph = CayleyGraph(PermutationGroups.lrx(n), device="cpu")
+    all_states = [list(p) for p in itertools.permutations(range(n))]
+
+    lengths = {}
+    for non_backtracking in [False, True]:
+        results = [
+            graph.beam_search(start_state=s, beam_width=1, max_steps=30, non_backtracking=non_backtracking)
+            for s in all_states
+        ]
+        lengths[non_backtracking] = [r.path_length if r.path_found else None for r in results]
+
+    # With beam width 1, the plain search can only follow the Hamming heuristic downhill and gets stuck almost
+    # immediately, while the non-backtracking search is forced to explore.
+    assert sum(x is not None for x in lengths[False]) < 15
+    assert sum(x is not None for x in lengths[True]) > 40
+    # No state solved by the plain search is solved worse (or not at all) by the non-backtracking one.
+    for plain_length, nbt_length in zip(lengths[False], lengths[True]):
+        if plain_length is not None:
+            assert nbt_length is not None and nbt_length <= plain_length
+
+
+def test_beam_search_simple_non_backtracking_finds_valid_path():
+    """Test that the path found with non-backtracking is a valid path."""
+    graph = CayleyGraph(PermutationGroups.lrx(8), device="cpu")
+    start_state = [3, 0, 2, 4, 5, 6, 7, 1]
+
+    result = graph.beam_search(
+        start_state=start_state, beam_width=10, max_steps=50, return_path=True, non_backtracking=True
+    )
+
+    _validate_beam_search_result(graph, start_state, result)
+
+
+def test_beam_search_simple_non_backtracking_disabled_by_default():
+    """Test that non_backtracking=False is exactly the old behavior."""
+    graph = CayleyGraph(PermutationGroups.lrx(8), device="cpu")
+    start_state = [3, 0, 2, 4, 5, 6, 7, 1]
+
+    result1 = graph.beam_search(start_state=start_state, beam_width=10, max_steps=50, return_path=True)
+    result2 = graph.beam_search(
+        start_state=start_state, beam_width=10, max_steps=50, return_path=True, non_backtracking=False
+    )
+
+    _validate_beam_search_result(graph, start_state, result1)
+    assert result1.path == result2.path
+    assert len(result1.debug_scores) > 0
+    assert result1.debug_scores == result2.debug_scores
+
+
+def test_beam_search_simple_non_backtracking_with_child_scores():
+    """Test that banned moves keep scores of children matched with the states they belong to."""
+    graph = CayleyGraph(PermutationGroups.lrx(8), device="cpu")
+    start_state = [3, 0, 2, 4, 5, 6, 7, 1]
+    kwargs = {"beam_width": 10, "max_steps": 50, "return_path": True, "non_backtracking": True}
+
+    result_scalar = graph.beam_search(start_state=start_state, predictor=Predictor(graph, "hamming"), **kwargs)
+    result_q = graph.beam_search(
+        start_state=start_state, predictor=_ChildrenHammingPredictor(graph), use_child_scores=True, **kwargs
+    )
+
+    _validate_beam_search_result(graph, start_state, result_q)
+    assert result_scalar.path == result_q.path
+    assert len(result_scalar.debug_scores) > 0
+    assert result_scalar.debug_scores == result_q.debug_scores
+
+
+def test_beam_search_simple_non_backtracking_with_canonical_dedup():
+    """Test that banned moves stay matched with their states when the beam is deduplicated by symmetries."""
+    graph_def = PermutationGroups.lrx(8)
+    graph = CayleyGraph(graph_def, device="cpu")
+    symmetry_group = SymmetryGroup.reflections(graph_def)
+    start_state = [3, 0, 2, 4, 5, 6, 7, 1]
+    kwargs = {
+        "beam_width": 10,
+        "max_steps": 50,
+        "return_path": True,
+        "non_backtracking": True,
+        "canonical_dedup": symmetry_group,
+    }
+
+    result_scalar = graph.beam_search(start_state=start_state, predictor=Predictor(graph, "hamming"), **kwargs)
+    result_q = graph.beam_search(
+        start_state=start_state, predictor=_ChildrenHammingPredictor(graph), use_child_scores=True, **kwargs
+    )
+
+    # Both deduplication by symmetries and banning of moves reorder and filter the expanded layer. If moves or score
+    # indexes were not filtered along with the states, they would be assigned to wrong states.
+    _validate_beam_search_result(graph, start_state, result_scalar)
+    assert result_scalar.path == result_q.path
+    assert len(result_scalar.debug_scores) > 0
+    assert result_scalar.debug_scores == result_q.debug_scores
+
+
+def test_beam_search_simple_non_backtracking_with_meet_in_the_middle():
+    """Test that non-backtracking works together with meet-in-the-middle."""
+    graph = CayleyGraph(PermutationGroups.lrx(8), device="cpu")
+    start_state = [3, 0, 2, 4, 5, 6, 7, 1]
+    bfs_result = graph.bfs(max_diameter=3, return_all_hashes=True)
+
+    result = graph.beam_search(
+        start_state=start_state,
+        beam_width=10,
+        max_steps=50,
+        return_path=True,
+        bfs_result_for_mitm=bfs_result,
+        non_backtracking=True,
+    )
+
+    _validate_beam_search_result(graph, start_state, result)
+
+
+def test_beam_search_simple_non_backtracking_all_moves_banned():
+    """Test that the search stops when every move from every state of the beam is banned."""
+    # The only generator is its own inverse, so from the second step on there is nowhere to go.
+    graph_def = CayleyGraphDef.create([[1, 0, 2, 3]], generator_names=["S"], central_state=[0, 1, 2, 3])
+    graph = CayleyGraph(graph_def, device="cpu")
+    start_state = [0, 1, 3, 2]
+
+    result = graph.beam_search(start_state=start_state, beam_width=1, max_steps=10, non_backtracking=True)
+    plain_result = graph.beam_search(start_state=start_state, beam_width=1, max_steps=10)
+
+    assert not result.path_found
+    # The central state is not reachable at all, but the plain search keeps oscillating until it runs out of steps.
+    assert not plain_result.path_found
+    assert len(result.debug_scores) == 1
+    assert len(plain_result.debug_scores) == 10
+
+
+def test_beam_search_simple_non_backtracking_requires_inverse_closed_generators():
+    """Test that non-backtracking is rejected when the inverse of a generator is not a generator."""
+    graph_def = PermutationGroups.lx(5)
+    assert graph_def.generators_inverse_map is None
+    graph = CayleyGraph(graph_def, device="cpu")
+
+    with pytest.raises(ValueError, match="inverse-closed"):
+        graph.beam_search(start_state=[4, 1, 0, 2, 3], non_backtracking=True)
+
+
+def test_beam_search_non_backtracking_not_supported_in_advanced_mode():
+    """Test that non-backtracking is rejected in "advanced" mode, which has history_depth for this."""
+    graph = CayleyGraph(PermutationGroups.lrx(5), device="cpu")
+
+    with pytest.raises(ValueError, match="only in 'simple' beam mode"):
+        graph.beam_search(start_state=[4, 1, 0, 2, 3], beam_mode="advanced", non_backtracking=True)
 
 
 # =============================================================================


### PR DESCRIPTION
Adds option `non_backtracking` to `search_simple`: it bans the move inverse to the move by which a state was reached. That move leads exactly to the state it came from, i.e. to a state of the previous layer, so with a narrow beam the plain search spends a large part of its width on walking back and forth.

**Only `search_simple`** — `search_advanced` already has `history_depth` for this (and does not support `return_path`). Passing `non_backtracking=True` with `beam_mode="advanced"` raises a clear error pointing at `history_depth`.

### How it works

* the id of the generator that produced each state of the beam is already tracked by `_expand_layer` (added for child scoring);
* `graph_def.generators_inverse_map` gives the inverse of that generator; if the generator set is not inverse-closed, the map is `None` and the option is rejected with a clear error;
* banned `(state, generator)` pairs are dropped **before** deduplication, so a state that is also produced by an allowed move (from another state of the beam) stays. This makes the ban strictly weaker than dropping states by hash, and never drops a state that is not reachable otherwise;
* memory cost is one generator id per state of the beam — in contrast to `history_depth`, which stores hashes of whole previous layers.

Banned moves are filtered together with the states on every step, so the option composes with `use_child_scores` and `canonical_dedup` (there are parity tests for both combinations).

### Measurements

Hamming heuristic, CPU, every state of the graph used as a start state, `max_steps=50`; the numbers are how many start states were solved:

| beam width | 1 | 2 | 5 | 10 |
|---|---|---|---|---|
| **LRX(5)**, 120 states | | | | |
| plain | 10 | 13 | 23 | 39 |
| `non_backtracking=True` | **44** | **62** | **113** | **116** |
| `advanced`, `history_depth=1` | 10 | 31 | 27 | 50 |
| **LRX(6)**, 720 states | | | | |
| plain | 12 | 14 | 29 | 54 |
| `non_backtracking=True` | **165** | **45** | **87** | **107** |
| `advanced`, `history_depth=1` | 12 | 22 | 32 | 54 |

No state solved by the plain search is solved with a longer path by the non-backtracking search (asserted for all 120 states of LRX(5) in a test).

Where it does **not** help: if the beam is wide enough to hold the whole layer, the ban only removes states. On the 2x2x2 cube (QTM) with beam width 10^4 and 20 random scrambles, plain solved 10/20, while both `non_backtracking=True` and `history_depth=1` solved 8/20 — but non-backtracking took 9.0s against 11.3s for `history_depth=1`, which additionally hashes each layer and intersects it with the stored hashes. This trade-off is documented in the docstring.

### Tests

15 new tests: banning at the level of layer expansion (no state comes from a banned pair, a state produced by an allowed move survives, the removed states are exactly the states of the previous layer), generators that are their own inverses (`cyclic_coxeter`), the fixed set of all 120 states of LRX(5) above, a valid path on LRX(8), `non_backtracking=False` giving exactly the old beam, combinations with child scoring / deduplication by symmetries / meet-in-the-middle, all moves banned (search stops instead of looping), a graph that is not inverse-closed, and the "advanced" mode error.

Also in this branch (base branch `feat/canonical-dedup`): a fix for flakiness of `test_beam_search_simple_cube222_canonical_dedup`, whose start state was an unseeded random scramble — a scramble landing within 10 moves of the central state left too few layers to compare (~1 failure in 40 runs).

`./lint.sh` and `RUN_SLOW_TESTS=1 pytest` are green on Python 3.12 (torch 2.13) and Python 3.9 (torch 2.8): 388 passed / 12 skipped / 3 xfailed.

### Open question for upstream

Whether this is worth having at all, given `history_depth` in `search_advanced` — to be decided by the measurements above (`search_simple` has no ban whatsoever today, and this one is O(1) in memory).



---

Based on #202, which is the base branch of this PR, so this diff is only its own change. #202 should be merged first.
