### PR TITLE
Add demo Q-model for lrx-14 to the library of pretrained models

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,13 +188,56 @@ Each such model is a PyTorch neural network which consists of 3 parts:
 * Model architecture hyperparameters (such as input size or sizes of hidden layers) - defined by `models.ModelConfig`.
 * Model weights - these are stored on Kaggle.
 
+A model has either one output - an estimate of the distance of the state it is applied to - or one output per generator
+of the graph (a Q-model), which estimates distances of all children of a state in one forward pass. Beam search uses a
+Q-model when called with `use_child_scores=True`, see `Predictor.score_children`.
+
 List of currently available models is 
 [here](https://github.com/cayleypy/cayleypy/blob/main/cayleypy/models/models_lib.py).
+
+Models can be trained with `cayleypy.train`. For example, this is how the Q-model for "lrx-14" was trained (in about 3
+minutes on a CPU):
+
+```python
+from cayleypy import CayleyGraph, PermutationGroups
+from cayleypy.models import ModelConfig
+from cayleypy.train import TrainConfig, Trainer
+
+graph = CayleyGraph(PermutationGroups.lrx(14), device="cpu", random_seed=42)
+model_config = ModelConfig(
+    model_type="RESMLP",
+    input_size=14,
+    num_classes_for_one_hot=14,
+    layers_sizes=[512, 512, 512],
+    n_outputs=graph.definition.n_generators,  # One output per generator, i.e. a Q-model.
+)
+train_config = TrainConfig(
+    n_epochs=200,
+    n_walks=1024,
+    rw_length=92,  # Diameter of this graph is 91.
+    batch_size=1024,
+    lr=1e-3,
+    lr_min=1e-5,
+    ema_decay=0.999,
+    anchors_depth=6,  # Mix in states whose exact distance is known from a breadth-first search.
+    anchors_fraction=0.02,
+    seed=42,
+    verbose=1,
+)
+trainer = Trainer(graph, model_config, train_config)
+trainer.train()
+trainer.save("lrx_14_q_resmlp.pt")  # Self-describing checkpoint: it also stores the config and the hash of the graph.
+```
+
+With beam width 1000, this model finds a path for 50 out of 50 uniformly random permutations of 14 elements (mean path
+length 61.2, diameter of the graph is 91), while the Hamming distance heuristic finds none of them.
 
 ### How to add a new predictor model
 1. Train your model.
 2. Verify that when used with beam search, it reliably finds the paths.
-3. Export weights to a file (using `torch.save(model.state_dict(), path`).
+3. Export weights to a file - either as a bare state dict (`torch.save(model.state_dict(), path)`) or as a
+    self-describing checkpoint (`models.save_checkpoint`, which is also what `train.Trainer.save` writes). Both are
+    accepted by `ModelConfig.load`.
 4. Upload weights as model on Kaggle, make it public and use open source license (MIT license is recommended).
 5. Make sure the graph for which your model should be used has unique name (that is, `CayleyGraphDef.name`). For
     example, `PermutationGroups.lrx(16)` has name "lrx-16". Also `prepare_graph` given this name should return
@@ -203,6 +246,9 @@ List of currently available models is
     * `weights_kaggle_id` is identifier of your saved model on Kaggle. This is what you would pass to 
       `kagglehub.model_download`.
     * `weights_path` is the name of file with weights.
+    * `graph_hash` is hash of the graph your model was trained for (see `models.graph_hash`; a checkpoint written by
+        `train.Trainer.save` already stores it). Set it, and loading your model for a graph that has the expected name
+        but another definition will fail instead of silently returning nonsense.
     * If your can be exactly described by one of available model types in `models/models.py`, use that model type
         with appropriate hyperparameters. If needed, add new hyperparameters to ModelConfig.
     * If your model architecture is very different from we already have in library, define new model type for it.

--- a/cayleypy/algo/find_path.py
+++ b/cayleypy/algo/find_path.py
@@ -56,6 +56,9 @@ def find_path(graph: CayleyGraph, start_state: AnyStateType, **kwargs) -> Option
     # If we have pre-trained model for beam search, use beam search with that predictor.
     if graph.definition.name in PREDICTOR_MODELS:
         predictor = Predictor.pretrained(graph)
+        # A model having one output per generator (Q-model) estimates distances of the children of a state rather than
+        # of the state itself, and can only be used to score children.
+        kwargs.setdefault("use_child_scores", predictor.n_outputs != 1)
         result = graph.beam_search(
             start_state=start_state,
             predictor=predictor,

--- a/cayleypy/algo/find_path_test.py
+++ b/cayleypy/algo/find_path_test.py
@@ -17,7 +17,7 @@ def test_find_path_pancake8():
 
 
 @pytest.mark.skipif(not RUN_SLOW_TESTS, reason="slow test")
-@pytest.mark.parametrize("graph_name", ["lx-9", "lrx-9", "lrx-12", "lrx-15", "lrx-16", "cube_2/2/2_6gensQTM"])
+@pytest.mark.parametrize("graph_name", ["lx-9", "lrx-9", "lrx-12", "lrx-14", "lrx-15", "lrx-16", "cube_2/2/2_6gensQTM"])
 def test_find_path(graph_name: str):
     graph = create_graph(name=graph_name)
     start_state = graph.random_walks(width=1, length=100)[0][-1]

--- a/cayleypy/algo/find_path_test.py
+++ b/cayleypy/algo/find_path_test.py
@@ -1,9 +1,12 @@
 import os
+from dataclasses import replace
 
 import pytest
 
 from cayleypy import create_graph, PermutationGroups, CayleyGraph
 from cayleypy import find_path
+from cayleypy.models import ModelConfig, save_checkpoint
+from cayleypy.models.models_lib import PREDICTOR_MODELS
 
 RUN_SLOW_TESTS = os.getenv("RUN_SLOW_TESTS") == "1"
 
@@ -24,3 +27,42 @@ def test_find_path(graph_name: str):
     path = find_path(graph, start_state)
     assert path is not None
     graph.validate_path(start_state, path)
+
+
+def test_find_path_scores_children_for_a_q_model(tmp_path, monkeypatch):
+    """Test that a pretrained model with one output per generator is used through child scoring.
+
+    Such a model estimates distances of the children of a state rather than of the state itself, so beam search must be
+    called with `use_child_scores=True` - otherwise it fails outright.
+    """
+    graph = CayleyGraph(PermutationGroups.lrx(5), device="cpu")
+    n_generators = graph.definition.n_generators
+    config = ModelConfig(
+        model_type="MLP",
+        input_size=5,
+        num_classes_for_one_hot=5,
+        layers_sizes=[16],
+        n_outputs=n_generators,
+    )
+    path_to_weights = tmp_path / "q_model.pt"
+    stored_config = save_checkpoint(path_to_weights, config.build_model(), config, graph.definition)
+    monkeypatch.setitem(
+        PREDICTOR_MODELS, graph.definition.name, replace(stored_config, weights_path=str(path_to_weights))
+    )
+
+    options: dict = {}
+    beam_search = CayleyGraph.beam_search
+
+    def recording_beam_search(self, **kwargs):
+        options.update(kwargs)
+        return beam_search(self, **kwargs)
+
+    monkeypatch.setattr(CayleyGraph, "beam_search", recording_beam_search)
+
+    start_state = [4, 1, 0, 2, 3]
+    found_path = find_path(graph, start_state)
+
+    assert found_path is not None
+    graph.validate_path(start_state, found_path)
+    assert options["use_child_scores"] is True
+    assert options["predictor"].n_outputs == n_generators

--- a/cayleypy/models/models.py
+++ b/cayleypy/models/models.py
@@ -38,22 +38,33 @@ def _download_from_kaggle(kaggle_id: str) -> str:
         ) from error
 
 
-def _load_state_dict(path: str, device: str) -> dict[str, Any]:
+def _load_state_dict(path: str, device: str, config: "ModelConfig") -> dict[str, Any]:
     """Loads state dict from a file with weights.
 
     Both bare state dicts and self-describing checkpoints written by :func:`cayleypy.models.save_checkpoint` are
-    accepted, so weights saved in either format can be used for a model of :data:`PREDICTOR_MODELS`.
+    accepted, so weights saved in either format can be used for a model of :data:`PREDICTOR_MODELS`. A checkpoint says
+    which graph it was trained for, and that is checked against `config`.
 
     :param path: Path to the file with weights.
     :param device: PyTorch device to load the weights to.
+    :param config: Config of the model the weights are being loaded into.
     :return: The state dict.
     """
     # `weights_only=True` is passed explicitly: files with weights contain only tensors and primitive values, so we
     # never need to unpickle arbitrary objects from them (and must not, because they are downloaded from the internet).
     data = torch.load(path, map_location=device, weights_only=True)
-    if isinstance(data, dict) and "state_dict" in data:
-        return data["state_dict"]
-    return data
+    if not isinstance(data, dict) or "state_dict" not in data:
+        # A bare state dict says nothing about itself, so there is nothing to check.
+        return data
+    stored_config = data.get("config")
+    stored_hash = stored_config.get("graph_hash") if isinstance(stored_config, dict) else None
+    if stored_hash is not None and config.graph_hash is not None and stored_hash != config.graph_hash:
+        # Shapes of the weights can match while they mean nothing for this graph, so this must not pass silently.
+        raise ValueError(
+            f"Checkpoint {path} was trained for another graph (hash in the checkpoint is {stored_hash}, hash in the "
+            f"config of the model is {config.graph_hash})."
+        )
+    return data["state_dict"]
 
 
 @dataclass(frozen=True)
@@ -138,7 +149,7 @@ class ModelConfig:
             path = self.weights_path
             if self.weights_kaggle_id is not None:
                 path = os.path.join(_download_from_kaggle(self.weights_kaggle_id), path)
-            model.load_state_dict(_load_state_dict(path, device))
+            model.load_state_dict(_load_state_dict(path, device, self))
         return model.to(device)
 
 

--- a/cayleypy/models/models.py
+++ b/cayleypy/models/models.py
@@ -6,7 +6,54 @@ from typing import Any, Optional
 
 import kagglehub
 import torch
+from kagglehub import exceptions as kagglehub_exceptions
 from torch import nn
+
+# Errors kagglehub raises when weights cannot be downloaded: no network, no credentials, no such model. They are
+# wrapped, because on their own they do not say which model of CayleyPy failed to load.
+_KAGGLEHUB_ERRORS = (
+    # Errors of the "requests" library, including kagglehub.exceptions.KaggleApiHTTPError, are subclasses of OSError.
+    OSError,
+    kagglehub_exceptions.BackendError,
+    kagglehub_exceptions.CredentialError,
+    kagglehub_exceptions.DataCorruptionError,
+    kagglehub_exceptions.NotFoundError,
+    kagglehub_exceptions.UnauthenticatedError,
+)
+
+
+def _download_from_kaggle(kaggle_id: str) -> str:
+    """Downloads Kaggle model with weights, reporting failures as errors naming that model.
+
+    :param kaggle_id: Id of the Kaggle model, as passed to `kagglehub.model_download`.
+    :return: Path to the directory the model was downloaded to.
+    """
+    try:
+        return kagglehub.model_download(kaggle_id)
+    except _KAGGLEHUB_ERRORS as error:
+        raise RuntimeError(
+            f'Could not download weights from Kaggle model "{kaggle_id}": {error}. Downloading weights needs network '
+            "access, and weights of a model that is not public also need Kaggle credentials to be configured (see "
+            "https://github.com/Kaggle/kagglehub)."
+        ) from error
+
+
+def _load_state_dict(path: str, device: str) -> dict[str, Any]:
+    """Loads state dict from a file with weights.
+
+    Both bare state dicts and self-describing checkpoints written by :func:`cayleypy.models.save_checkpoint` are
+    accepted, so weights saved in either format can be used for a model of :data:`PREDICTOR_MODELS`.
+
+    :param path: Path to the file with weights.
+    :param device: PyTorch device to load the weights to.
+    :return: The state dict.
+    """
+    # `weights_only=True` is passed explicitly: files with weights contain only tensors and primitive values, so we
+    # never need to unpickle arbitrary objects from them (and must not, because they are downloaded from the internet).
+    data = torch.load(path, map_location=device, weights_only=True)
+    if isinstance(data, dict) and "state_dict" in data:
+        return data["state_dict"]
+    return data
 
 
 @dataclass(frozen=True)
@@ -76,10 +123,8 @@ class ModelConfig:
         if self.weights_path is not None:
             path = self.weights_path
             if self.weights_kaggle_id is not None:
-                model_dir = kagglehub.model_download(self.weights_kaggle_id)
-                path = os.path.join(model_dir, path)
-            # Weights in this format are bare state dicts, so we never need to unpickle arbitrary objects from them.
-            model.load_state_dict(torch.load(path, map_location=device, weights_only=True))
+                path = os.path.join(_download_from_kaggle(self.weights_kaggle_id), path)
+            model.load_state_dict(_load_state_dict(path, device))
         return model.to(device)
 
 

--- a/cayleypy/models/models_lib.py
+++ b/cayleypy/models/models_lib.py
@@ -4,6 +4,19 @@ from .models import ModelConfig
 
 # Pretrained models to be used as predictors for Beam Search.
 PREDICTOR_MODELS = {
+    # Q-model: it has one output per generator, so it estimates distances of all children of a state in one forward
+    # pass, and beam search must be called with `use_child_scores=True` to use it. Trained with `cayleypy.train`, see
+    # section "Predictor models" of README for the training recipe.
+    "lrx-14": ModelConfig(
+        model_type="RESMLP",
+        input_size=14,
+        num_classes_for_one_hot=14,
+        layers_sizes=[512, 512, 512],
+        n_outputs=3,
+        graph_hash="d697b93f3ca3b17f695af3e046b3438c71c3521d9a4955ecf78b85e5fd27ec47",
+        weights_kaggle_id="rokham/lrx-14-q/pyTorch/resmlp-512x3/1",
+        weights_path="lrx_14_q_resmlp.pt",
+    ),
     "lrx-16": ModelConfig(
         model_type="MLP",
         input_size=16,

--- a/cayleypy/models/models_lib_test.py
+++ b/cayleypy/models/models_lib_test.py
@@ -48,8 +48,9 @@ def test_lrx_14_model_finds_paths():
         assert result.path_found
         assert result.path is not None
         assert torch.equal(graph.apply_path(start_state, result.path).reshape((-1)), graph.central_state)
-        # Diameter of this graph is 91, and the model should be much better than the worst case.
-        assert result.path_length <= 91
+        # Diameter of this graph is 91, and the model is much better than the worst case: the longest of these ten
+        # paths was 71 moves when this model was added.
+        assert result.path_length <= 80
 
 
 def test_pretrained_without_model():

--- a/cayleypy/models/models_lib_test.py
+++ b/cayleypy/models/models_lib_test.py
@@ -1,9 +1,10 @@
 import os
+from dataclasses import replace
 
 import pytest
 import torch
 
-from .checkpoint import graph_hash
+from .checkpoint import graph_hash, save_checkpoint
 from .models import ModelConfig
 from .models_lib import PREDICTOR_MODELS
 from .. import prepare_graph, Predictor, CayleyGraph
@@ -72,3 +73,23 @@ def test_pretrained_rejects_model_for_another_graph(monkeypatch):
     monkeypatch.setitem(PREDICTOR_MODELS, "lrx-5", config)
     with pytest.raises(ValueError, match="was trained for another graph"):
         Predictor.pretrained(graph)
+
+
+def test_load_rejects_checkpoint_trained_for_another_graph(tmp_path):
+    """Test that weights of a model trained for another graph are not loaded silently.
+
+    A checkpoint says which graph it was trained for, so a file that happens to have weights of the right shape can
+    still be detected as the wrong file - which is what keeps a `PREDICTOR_MODELS` entry from shipping nonsense.
+    """
+    config = ModelConfig(model_type="MLP", input_size=5, num_classes_for_one_hot=5, layers_sizes=[8])
+    other_graph = PermutationGroups.lrx(5, k=2)
+    path = tmp_path / "weights.pt"
+    save_checkpoint(path, config.build_model(), config, other_graph)
+
+    for_this_graph = replace(config, weights_path=str(path), graph_hash=graph_hash(PermutationGroups.lrx(5)))
+    with pytest.raises(ValueError, match="trained for another graph"):
+        for_this_graph.load()
+
+    # The same checkpoint loads when the config says it is for the graph the weights were trained for.
+    for_that_graph = replace(config, weights_path=str(path), graph_hash=graph_hash(other_graph))
+    assert for_that_graph.load() is not None

--- a/cayleypy/models/models_lib_test.py
+++ b/cayleypy/models/models_lib_test.py
@@ -1,15 +1,73 @@
+import os
+
+import pytest
 import torch
 
+from .checkpoint import graph_hash
+from .models import ModelConfig
 from .models_lib import PREDICTOR_MODELS
 from .. import prepare_graph, Predictor, CayleyGraph
+from ..graphs_lib import PermutationGroups
+
+RUN_SLOW_TESTS = os.getenv("RUN_SLOW_TESTS") == "1"
 
 
 def test_loads_predictor_models():
     # Checks that all models can be loaded and successfully return prediction for central state of the graph.
     # This test does not check model quality.
-    for graph_name in PREDICTOR_MODELS:
+    for graph_name, config in PREDICTOR_MODELS.items():
         graph_def = prepare_graph(graph_name)
         graph = CayleyGraph(graph_def)
         predictor = Predictor.pretrained(graph)
-        ans = predictor(torch.tensor(graph_def.central_state, device=graph.device).reshape((1, -1)))
-        assert ans.shape == (1,)
+        states = torch.tensor(graph_def.central_state, device=graph.device).reshape((1, -1))
+        if config.n_outputs == 1:
+            assert predictor(states).shape == (1,)
+        else:
+            # A model with one output per generator predicts distances of all children of a state, not of the state
+            # itself, so it is used through score_children.
+            assert predictor.score_children(states).shape == (1, graph_def.n_generators)
+
+
+@pytest.mark.skipif(not RUN_SLOW_TESTS, reason="This test is slow.")
+def test_lrx_14_model_finds_paths():
+    # Checks that the model for "lrx-14" does what a model of this library is for: reliably finds paths in beam search.
+    # With this beam width it solves random states of this graph consistently (50 out of 50 when this model was added),
+    # while the Hamming distance heuristic solves none of them.
+    graph = CayleyGraph(prepare_graph("lrx-14"), device="cpu", random_seed=0)
+    predictor = Predictor.pretrained(graph)
+    generator = torch.Generator().manual_seed(11)
+    for _ in range(10):
+        start_state = torch.randperm(graph.definition.state_size, generator=generator)
+        result = graph.beam_search(
+            start_state=start_state,
+            predictor=predictor,
+            beam_width=1000,
+            return_path=True,
+            use_child_scores=True,
+        )
+        assert result.path_found
+        assert result.path is not None
+        assert torch.equal(graph.apply_path(start_state, result.path).reshape((-1)), graph.central_state)
+        # Diameter of this graph is 91, and the model should be much better than the worst case.
+        assert result.path_length <= 91
+
+
+def test_pretrained_without_model():
+    graph = CayleyGraph(PermutationGroups.lrx(5), device="cpu")
+    with pytest.raises(KeyError, match="No pretrained model for this graph"):
+        Predictor.pretrained(graph)
+
+
+def test_pretrained_rejects_model_for_another_graph(monkeypatch):
+    graph = CayleyGraph(PermutationGroups.lrx(5), device="cpu")
+    another_graph_def = PermutationGroups.lrx(5, k=2)
+    config = ModelConfig(
+        model_type="MLP",
+        input_size=5,
+        num_classes_for_one_hot=5,
+        layers_sizes=[8],
+        graph_hash=graph_hash(another_graph_def),
+    )
+    monkeypatch.setitem(PREDICTOR_MODELS, "lrx-5", config)
+    with pytest.raises(ValueError, match="was trained for another graph"):
+        Predictor.pretrained(graph)

--- a/cayleypy/models/models_test.py
+++ b/cayleypy/models/models_test.py
@@ -1,7 +1,10 @@
 import json
+from dataclasses import replace
 
+import kagglehub
 import pytest
 import torch
+from kagglehub import exceptions as kagglehub_exceptions
 
 from .checkpoint import load_checkpoint, save_checkpoint
 from .models import MlpModel, ModelConfig, ResMlpModel
@@ -177,6 +180,36 @@ def test_checkpoint_round_trip(tmp_path):
         assert loaded_config == config
         with torch.no_grad():
             assert torch.equal(loaded_model(STATES), model(STATES))
+
+
+def test_load_weights_from_checkpoint(tmp_path):
+    # Weights for a model of PREDICTOR_MODELS can be saved as a self-describing checkpoint, not only as a bare
+    # state dict, so that the same file can be loaded by both load_checkpoint and ModelConfig.load.
+    config = ModelConfig(model_type="RESMLP", input_size=5, num_classes_for_one_hot=5, layers_sizes=[8], n_outputs=3)
+    model = config.build_model()
+    checkpoint_path = tmp_path / "checkpoint.pt"
+    save_checkpoint(checkpoint_path, model, config)
+    state_dict_path = tmp_path / "state_dict.pt"
+    torch.save(model.state_dict(), state_dict_path)
+
+    for path in [checkpoint_path, state_dict_path]:
+        loaded_model = replace(config, weights_path=str(path)).load()
+        with torch.no_grad():
+            assert torch.equal(loaded_model(STATES), model(STATES))
+
+
+def test_load_reports_failed_kaggle_download(monkeypatch):
+    def fail(handle):
+        raise kagglehub_exceptions.NotFoundError(f"Model {handle} not found.")
+
+    monkeypatch.setattr(kagglehub, "model_download", fail)
+    config = replace(
+        ModelConfig(model_type="MLP", input_size=5, num_classes_for_one_hot=5, layers_sizes=[8]),
+        weights_kaggle_id="nobody/no-such-model/pyTorch/v1/1",
+        weights_path="weights.pt",
+    )
+    with pytest.raises(RuntimeError, match="Could not download weights from Kaggle model"):
+        config.load()
 
 
 def test_build_model_with_non_positive_n_outputs():

--- a/cayleypy/predictor.py
+++ b/cayleypy/predictor.py
@@ -4,6 +4,7 @@ from typing import Callable
 
 import torch
 
+from .models.checkpoint import graph_hash
 from .models.models_lib import PREDICTOR_MODELS
 
 if typing.TYPE_CHECKING:
@@ -55,11 +56,25 @@ class Predictor:
 
     @staticmethod
     def pretrained(graph: "CayleyGraph"):
-        """Loads pre-trained predictor for this graph."""
+        """Loads pre-trained predictor for this graph.
+
+        Graphs are looked up by name, so if the config of the pretrained model says which graph the model was trained
+        for (`ModelConfig.graph_hash`), it is checked that it is this graph. Without that check, a graph that has the
+        expected name but another definition would silently get a model that means nothing for it - and for a model
+        having one output per generator, even reordering the generators is enough to make its outputs meaningless.
+
+        :param graph: Graph to load the model for.
+        :return: Predictor using the pretrained model.
+        """
         if graph.definition.name not in PREDICTOR_MODELS:
             raise KeyError("No pretrained model for this graph.")
-        model = PREDICTOR_MODELS[graph.definition.name].load(graph.device)
-        return Predictor(graph, model)
+        config = PREDICTOR_MODELS[graph.definition.name]
+        if config.graph_hash is not None and config.graph_hash != graph_hash(graph.definition):
+            raise ValueError(
+                f'Pretrained model for "{graph.definition.name}" was trained for another graph (hash in the config of '
+                f"the model is {config.graph_hash}, hash of the given graph is {graph_hash(graph.definition)})."
+            )
+        return Predictor(graph, config.load(graph.device))
 
     def predict_batched(self, states: torch.Tensor) -> torch.Tensor:
         """Applies the underlying model to `states`, splitting them into batches if there are too many.


### PR DESCRIPTION
Adds the first model to `PREDICTOR_MODELS` that was trained with `cayleypy.train` (#9, #10), and the first one with one output per generator — a Q-model (#1, #3), which beam search uses through `Predictor.score_children` (#2).

Motivation: the architectures added earlier in this series (#3, #5, #6) had no weights, so nothing in the library used them. This is the failure mode of upstream cayleypy/cayleypy#151 — a training PR with nothing to show for it — and this PR closes it.

## The model

`"lrx-14"`: `ResMlpModel` (model type `"RESMLP"`), one-hot input, 3 residual blocks of 512 neurons, 3 outputs — one per generator (L, R, X). 631k parameters, weights on Kaggle under MIT: [rokham/lrx-14-q](https://www.kaggle.com/models/rokham/lrx-14-q).

Measured on 50 uniformly random permutations of 14 elements (`torch.randperm`, seed 11), beam width 1000, `use_child_scores=True`:

| Predictor | Solved | Mean path length | Max |
|---|---|---|---|
| This model | **50 / 50** | 61.2 | 86 |
| Hamming distance | 0 / 50 | — | — |

The diameter of this graph is 91, so the paths found are well below the worst case. At beam width 100 the model still solves 17 out of 20. Trained in ~3 minutes on a CPU; the exact recipe (200 epochs, 1024 walks of length 92, 2% of BFS anchors, EMA) is in README, so the checkpoint is reproducible.

Where the recipe runs out: with 4× the training budget, the same architecture on `lrx-18` solves 19/20 and on `lrx-20` only 8/10 (beam width 1000–10000). The loss plateaus after ~5 epochs there, i.e. it is limited by the targets, not by the budget — sparse Q-targets from "classic" random walks are inflated far from the central state. That is what the Bellman/DAVI fine-tuning planned later in the series is for, and it is why the demo is registered for a graph where the current recipe is reliable.

## Changes besides the registry entry

- **`ModelConfig.load` accepts self-describing checkpoints**, not only bare state dicts, so weights written by `save_checkpoint`/`Trainer.save` (#1, #9) can be used for a model of this library as is. Detection is by the `"state_dict"` key.
- **Failures of the Kaggle download are reported as errors naming the model** instead of a bare kagglehub error, and saying that the download needs network access (and credentials for a model that is not public).
- **`Predictor.pretrained` checks `ModelConfig.graph_hash`** against the graph it is called for. Models are looked up by graph name, so without this check a graph that has the expected name but another definition silently gets a model that means nothing for it — and for a model with one output per generator, even reordering the generators is enough to make its outputs meaningless.
- **README**: how a Q-model differs from a single-output model and how beam search uses it, the training recipe for this model, and two amendments to "How to add a new predictor model" (weights can be a checkpoint; set `graph_hash`).

## Tests

- `test_loads_predictor_models` (the guide's step 9, real weights from Kaggle, no skipif) now also covers models with one output per generator: for those it checks the shape of `score_children`. Anonymous download of the new weights is verified, so CI needs no Kaggle credentials.
- `test_lrx_14_model_finds_paths` (slow tier): the registered model solves 10 random states at beam width 1000, every path is replayed with `apply_path` and must end in the central state, and its length must be at most the diameter.
- Error cases: `Predictor.pretrained` for a graph without a model, and for a model whose `graph_hash` is of another graph; `ModelConfig.load` for a failing Kaggle download (`RuntimeError` naming the model); `ModelConfig.load` from both weight formats gives identical predictions.

`./lint.sh` green (black, pylint 10.00/10, mypy), `black --check .` green, `docs/build_docs.sh` (`-W`) green, doctests green. `RUN_SLOW_TESTS=1 pytest` = **426 passed / 12 skipped / 3 xfailed** on Python 3.12 (torch 2.13) and on Python 3.9 (torch 2.8).

Base is `base/demo-checkpoint`, a mechanical merge of `feat/train-data-sources` (#10), `feat/resmlp-qmlp` (#3) and `feat/child-scored-beam` (#2) — a Q-model needs the multi-output architectures to exist and the child-scored beam step to be usable at all. Draft until those are merged.



---

Based on `base/demo-checkpoint`, a mechanical merge of #193, #201 and #194 with no changes of its own. All three should be merged first.
