### PR TITLE
Add Bellman (DAVI) fine-tuning for distance-estimating models

### DIFF
--- a/cayleypy/__init__.py
+++ b/cayleypy/__init__.py
@@ -9,6 +9,8 @@ from .models import ModelConfig, load_checkpoint, save_checkpoint
 from .predictor import Predictor
 from .puzzles import Puzzles, GapPuzzles
 from .train import (
+    BellmanTargets,
+    BellmanTrainer,
     BfsAnchors,
     DataSource,
     Loss,
@@ -22,5 +24,6 @@ from .train import (
     Trainer,
     TrainingData,
     TrainResult,
+    bellman_targets,
     make_loss,
 )

--- a/cayleypy/train/__init__.py
+++ b/cayleypy/train/__init__.py
@@ -1,3 +1,4 @@
+from .bellman import BellmanTargets, BellmanTrainer, bellman_targets
 from .config import TrainConfig
 from .data import (
     BfsAnchors,

--- a/cayleypy/train/bellman.py
+++ b/cayleypy/train/bellman.py
@@ -70,6 +70,12 @@ def _values(graph: "CayleyGraph", target: Predictor, encoded_states: torch.Tenso
     with torch.no_grad():
         output = target.predict_batched(graph.decode_states(encoded_states))
     if output.dim() == 2:
+        n_generators = graph.definition.n_generators
+        if output.shape[1] != n_generators:
+            raise ValueError(
+                f"Target model returned {output.shape[1]} scores per state, but a model estimating distances of the "
+                f"children of a state must return one score per generator, of which this graph has {n_generators}."
+            )
         # A Q-model estimates distances of children, and a state is one move away from its nearest child.
         values = 1.0 + output.min(dim=1).values
     elif output.dim() == 1:
@@ -197,7 +203,9 @@ class BellmanTargets(DataSource):
 
     def _frozen_copy(self, model: TargetModel) -> Predictor:
         """Copies the given model and makes it usable for computing targets only."""
-        target = copy.deepcopy(model)
+        # A Predictor holds the graph, which is not what is being copied here (and copying it would duplicate the
+        # generators and the hasher on the device), so only the model inside it is taken.
+        target = copy.deepcopy(model.predict if isinstance(model, Predictor) else model)
         if isinstance(target, nn.Module):
             target.eval()
             for parameter in target.parameters():

--- a/cayleypy/train/bellman.py
+++ b/cayleypy/train/bellman.py
@@ -1,0 +1,298 @@
+"""Bellman (DAVI) targets - training data whose targets come from the model itself.
+
+A random walk labels a state with the number of steps at which it visited that state, which is an upper estimate of the
+true distance, and a loose one for distant states. The Bellman operator produces targets that do not have this problem,
+using the fact that a state is exactly one move away from its children::
+
+    y(s) = 0                              if s is the central state,
+    y(s) = 1 + min_a V_target(child_a(s)) otherwise,
+
+where ``V_target`` is a frozen copy of the model being trained (the `target`). Estimates then propagate outwards from
+the central state, whose distance is known exactly - this is what the DAVI ("deep approximate value iteration")
+algorithm does, and it is why anchors (states whose exact distance is known) must be mixed into the data: bootstrapped
+targets say how far states are from each other, and something has to say where the goal is, otherwise the whole scale
+drifts. :class:`BellmanTrainer` mixes anchors in and refreshes the target for you.
+
+Example:
+
+>>> import torch
+>>> from cayleypy import CayleyGraph, PermutationGroups
+>>> from cayleypy.train import bellman_targets
+>>> graph = CayleyGraph(PermutationGroups.lrx(4), device="cpu")
+>>> model = lambda states: torch.full((states.shape[0],), 5.0)  # Predicts 5 for every state.
+>>> # The central state, a state next to it (whose target is 1 whatever the model says), and a state further away.
+>>> bellman_targets(graph, torch.tensor([[0, 1, 2, 3], [1, 2, 3, 0], [0, 2, 3, 1]]), model).targets
+tensor([0., 1., 6.])
+"""
+
+import copy
+import typing
+from typing import Callable, Optional, Union
+
+import torch
+from torch import nn
+
+from .config import TrainConfig
+from .data import BfsAnchors, DataSource, MixtureDataSource, RandomWalksSource, TrainingData
+from .trainer import Trainer
+from ..predictor import Predictor
+
+if typing.TYPE_CHECKING:
+    from ..cayley_graph import CayleyGraph
+    from ..models.models import ModelConfig
+
+# Anything that can estimate distances of states: a model, a Predictor, or any callable mapping states to scores.
+TargetModel = Union[nn.Module, Predictor, Callable[[torch.Tensor], torch.Tensor]]
+
+
+def _check_n_outputs(graph: "CayleyGraph", n_outputs: int) -> None:
+    """Checks that a model with this number of outputs can be trained on Bellman targets for this graph."""
+    n_generators = graph.definition.n_generators
+    if n_outputs not in (1, n_generators):
+        raise ValueError(
+            f"n_outputs must be either 1 or the number of generators of this graph ({n_generators}), got {n_outputs}."
+        )
+
+
+def _is_central_state(graph: "CayleyGraph", encoded_states: torch.Tensor) -> torch.Tensor:
+    """Returns mask of states that are the central state (compared by hash, as elsewhere in this library)."""
+    return graph.hasher.make_hashes(encoded_states) == graph.central_state_hash[0]
+
+
+def _values(graph: "CayleyGraph", target: Predictor, encoded_states: torch.Tensor) -> torch.Tensor:
+    """Estimates distances of given states with the target model, with the distance of the central state pinned to 0.
+
+    :param graph: Graph the states are in.
+    :param target: Predictor wrapping the target model.
+    :param encoded_states: States in internal representation.
+    :return: Tensor of shape ``[n_states]`` with estimated distances.
+    """
+    with torch.no_grad():
+        output = target.predict_batched(graph.decode_states(encoded_states))
+    if output.dim() == 2:
+        # A Q-model estimates distances of children, and a state is one move away from its nearest child.
+        values = 1.0 + output.min(dim=1).values
+    elif output.dim() == 1:
+        values = output
+    else:
+        raise ValueError(
+            f"Target model returned output of shape {tuple(output.shape)}, but one score per state (1-D output) or one "
+            "score per generator (2-D output) was expected."
+        )
+    # Distances cannot be negative, and a negative estimate would drag targets of everything around it below 0. Targets
+    # are detached, so that training on them never propagates gradients into the target model.
+    values = values.detach().to(torch.float32).clamp_min(0.0)
+    # The distance of the central state is known, whatever the model says about it - and it is the only thing that ties
+    # bootstrapped targets to the actual distances.
+    return torch.where(_is_central_state(graph, encoded_states), torch.zeros_like(values), values)
+
+
+def bellman_targets(
+    graph: "CayleyGraph",
+    states: torch.Tensor,
+    target: TargetModel,
+    n_outputs: int = 1,
+) -> TrainingData:
+    """Computes Bellman targets for given states with a target model.
+
+    The target of a state is one more than the smallest estimated distance of its children, and 0 for the central state
+    (see the module docstring). For a Q-model, whose outputs are estimated distances of the children themselves, the
+    target of output ``a`` is the estimated distance of ``child_a(s)`` - so unlike targets from a random walk (see
+    :class:`cayleypy.train.SparseQSampler`), all outputs are labeled.
+
+    All estimates are clamped at 0, and the estimate for the central state is 0 regardless of what the model says. This
+    makes the target of every state next to the central state exactly 1, which is what makes value iteration start.
+
+    Computing targets needs the target model applied to all children of `states`, i.e. `n_generators` times more model
+    evaluations than one training step on the same states. The target model does not have to have the same number of
+    outputs as the model being trained: what is needed of it is an estimated distance of a state, and a Q-model gives
+    that as one more than the smallest of its outputs.
+
+    :param graph: Graph the states are in.
+    :param states: States (in decoded representation) to compute targets for, of shape ``[n_states, state_size]``.
+    :param target: Model to compute targets with - a `torch.nn.Module`, a :class:`cayleypy.Predictor`, or any callable
+        mapping states to estimated distances. It is applied without gradients, but note that a module passed here is
+        put in eval mode (as by :class:`cayleypy.Predictor`) and is not copied, so training it changes future targets.
+    :param n_outputs: Number of outputs of the model to train - 1 for a model estimating the distance of a state, or the
+        number of generators for a Q-model estimating distances of all children of a state.
+    :return: States with their Bellman targets.
+    """
+    _check_n_outputs(graph, n_outputs)
+    predictor = target if isinstance(target, Predictor) else Predictor(graph, target)
+    n_generators = graph.definition.n_generators
+    encoded_states = graph.encode_states(states)
+    n_states = int(encoded_states.shape[0])
+    child_values = _values(graph, predictor, graph.get_neighbors(encoded_states))
+    # get_neighbors returns children of all states for the first generator, then for the second one, and so on.
+    child_values = child_values.reshape((n_generators, n_states)).transpose(0, 1).contiguous()
+    decoded_states = graph.decode_states(encoded_states)
+    if n_outputs != 1:
+        # Outputs of a Q-model are estimated distances of children, which is exactly what was just computed.
+        return TrainingData(states=decoded_states, targets=child_values)
+    targets = 1.0 + child_values.min(dim=1).values
+    is_central = _is_central_state(graph, encoded_states)
+    return TrainingData(states=decoded_states, targets=torch.where(is_central, torch.zeros_like(targets), targets))
+
+
+class BellmanTargets(DataSource):
+    """Training data whose states come from another source and whose targets come from a frozen copy of the model.
+
+    States are taken from `states_source` (usually random walks - they are the only cheap way to reach distant states)
+    and their targets are recomputed by :func:`bellman_targets`, so whatever targets that source produces are ignored.
+
+    The target model is a frozen copy, so training the model does not change targets until :meth:`update_target` is
+    called with the new weights - which is what keeps value iteration from chasing its own tail.
+    :class:`BellmanTrainer` does that once every `TrainConfig.bellman_target_update_period` epochs.
+
+    Example:
+
+    >>> import torch
+    >>> from cayleypy import CayleyGraph, PermutationGroups
+    >>> from cayleypy.train import BellmanTargets, RandomWalksSource
+    >>> _ = torch.manual_seed(0)
+    >>> graph = CayleyGraph(PermutationGroups.lrx(4), device="cpu")
+    >>> model = torch.nn.Linear(4, 1)
+    >>> walks = RandomWalksSource(graph, n_walks=4, rw_length=5)
+    >>> len(BellmanTargets(graph, walks, lambda states: model(states.to(torch.float32)).squeeze(1)).generate())
+    20
+    """
+
+    def __init__(
+        self,
+        graph: "CayleyGraph",
+        states_source: DataSource,
+        target_model: TargetModel,
+        n_outputs: int = 1,
+    ):
+        """Initializes BellmanTargets.
+
+        :param graph: Graph to compute targets in.
+        :param states_source: Where to take states to label. Only states of its data are used, its targets are replaced
+            by the bootstrapped ones.
+        :param target_model: Model to compute targets with. It is copied and frozen, so training the original model does
+            not change targets until :meth:`update_target` is called.
+        :param n_outputs: Number of outputs of the model to train - 1 for a model estimating the distance of a state, or
+            the number of generators for a Q-model.
+        """
+        _check_n_outputs(graph, n_outputs)
+        self.graph = graph
+        self.states_source = states_source
+        self.n_outputs = int(n_outputs)
+        self.target = self._frozen_copy(target_model)
+
+    def update_target(self, model: TargetModel) -> None:
+        """Replaces the target with a frozen copy of the given model, so that later targets use its weights.
+
+        :param model: Model to compute targets with from now on.
+        """
+        self.target = self._frozen_copy(model)
+
+    def generate(self) -> TrainingData:
+        """Takes states from `states_source` and computes Bellman targets for them.
+
+        :return: States with their Bellman targets.
+        """
+        states = self.states_source.generate().states
+        return bellman_targets(self.graph, states, self.target, n_outputs=self.n_outputs)
+
+    def _frozen_copy(self, model: TargetModel) -> Predictor:
+        """Copies the given model and makes it usable for computing targets only."""
+        target = copy.deepcopy(model)
+        if isinstance(target, nn.Module):
+            target.eval()
+            for parameter in target.parameters():
+                parameter.requires_grad_(False)
+        return Predictor(self.graph, target)
+
+
+class BellmanTrainer(Trainer):
+    """Trains a model on Bellman targets, refreshing the target as training goes (the DAVI algorithm).
+
+    This is the same training loop as :class:`cayleypy.train.Trainer`, with the data of every epoch built as:
+
+    - states from random walks (or from `states_source`), with targets computed by :func:`bellman_targets` from a frozen
+      copy of the model - see :class:`BellmanTargets`;
+    - anchors - states around the central state with exact distances from a breadth-first search of depth
+      `TrainConfig.bellman_anchors_depth` (1 by default, i.e. the central state and its neighbors), taking
+      `TrainConfig.anchors_fraction` of the data. Unlike in :class:`cayleypy.train.Trainer`, anchors are not optional:
+      bootstrapped targets only say how far states are from each other, and without exactly known distances the scale of
+      the predictions drifts.
+
+    Every `TrainConfig.bellman_target_update_period` epochs the target is refreshed from the model being trained (from
+    its EMA copy, if one is maintained). Refreshing every epoch (the default) means the target is the EMA copy, i.e. it
+    lags behind by design; a larger period gives a target that is held fixed for several epochs instead.
+
+    This is normally used to fine-tune a model pretrained on random walks, whose targets are upper estimates of the
+    distance - and the reason to do it is that the estimates are loose exactly where beam search spends its time.
+    Fine-tuning starts from a checkpoint (:meth:`from_checkpoint`) with a learning rate lower than the one used for
+    pretraining: targets move as the model moves, and a large step in that feedback loop makes training oscillate.
+
+    Q-models (one output per generator) are trained here as well, and get more out of it than models with one output: a
+    random walk labels two outputs of a state (see :class:`cayleypy.train.SparseQSampler`), while Bellman targets label
+    all of them, and they do not need walks to be paths, so `TrainConfig.rw_mode` is honored for Q-models too.
+
+    Example:
+
+    >>> from cayleypy import CayleyGraph, PermutationGroups
+    >>> from cayleypy.models import ModelConfig
+    >>> from cayleypy.train import BellmanTrainer, TrainConfig
+    >>> graph = CayleyGraph(PermutationGroups.lrx(4), device="cpu")
+    >>> model_config = ModelConfig(model_type="MLP", input_size=4, num_classes_for_one_hot=4, layers_sizes=[16])
+    >>> train_config = TrainConfig(n_epochs=2, n_walks=8, rw_length=4, batch_size=16, lr=1e-4, seed=0)
+    >>> result = BellmanTrainer(graph, model_config, train_config).train()
+    >>> len(result.losses)
+    2
+    """
+
+    def __init__(
+        self,
+        graph: "CayleyGraph",
+        model_config: "ModelConfig",
+        config: Optional[TrainConfig] = None,
+        model: Optional[nn.Module] = None,
+        states_source: Optional[DataSource] = None,
+    ):
+        """Initializes BellmanTrainer.
+
+        :param graph: Graph for which to train the model.
+        :param model_config: Config describing the model to train, see :class:`cayleypy.train.Trainer`.
+        :param config: Configuration of the training process. Defaults to `TrainConfig()`.
+        :param model: Model to train (optional). Defaults to a model built from `model_config`. Pass a model, or use
+            :meth:`from_checkpoint`, to fine-tune an existing one.
+        :param states_source: Where to take states to compute targets for (optional). Defaults to random walks
+            described by `config`. Its targets are ignored - only states are used.
+        """
+        self._states_source = states_source
+        super().__init__(graph, model_config, config=config, model=model)
+
+    def _make_data_source(self) -> DataSource:
+        """Creates the mixture of Bellman targets and anchors described by the config."""
+        config = self.config
+        n_outputs = self.model_config.n_outputs
+        states_source = self._states_source
+        if states_source is None:
+            states_source = RandomWalksSource(
+                self.graph,
+                n_walks=config.n_walks,
+                rw_length=config.rw_length,
+                mode=config.rw_mode,
+                nbt_history_depth=config.nbt_history_depth,
+            )
+        # The model itself is the first target: the EMA copy does not exist yet (it is created after the data source)
+        # and it starts as a copy of the model anyway.
+        self.bellman_source = BellmanTargets(self.graph, states_source, self.model, n_outputs=n_outputs)
+        # Anchors sample exactly their share of what the states source generates, so the mixture has nothing to throw
+        # away. There are few states with exact distances near the central state, so they are sampled with repetitions.
+        fraction = config.anchors_fraction
+        size = max(1, int(round(fraction / (1 - fraction) * config.n_walks * config.rw_length)))
+        anchors = BfsAnchors(self.graph, depth=config.bellman_anchors_depth, size=size, n_outputs=n_outputs)
+        return MixtureDataSource([self.bellman_source, anchors], [1 - fraction, fraction])
+
+    def train_epoch(self) -> float:
+        """Refreshes the target if it is due, then generates data for one epoch and makes one pass over it.
+
+        :return: Mean loss on this epoch.
+        """
+        if self.epoch % self.config.bellman_target_update_period == 0:
+            self.bellman_source.update_target(self.model_for_inference())
+        return super().train_epoch()

--- a/cayleypy/train/bellman.py
+++ b/cayleypy/train/bellman.py
@@ -13,6 +13,12 @@ algorithm does, and it is why anchors (states whose exact distance is known) mus
 targets say how far states are from each other, and something has to say where the goal is, otherwise the whole scale
 drifts. :class:`BellmanTrainer` mixes anchors in and refreshes the target for you.
 
+The recursion above looks at where the moves from a state lead, so it bootstraps the distance to the central state,
+while the anchors it is mixed with come from a search starting at the central state and measure the distance from it.
+These are the same distance only for inverse-closed generators, which is why :class:`BellmanTrainer` requires them - for
+a graph whose generators are not inverse closed, train on the graph returned by
+``CayleyGraph.with_inverted_generators``.
+
 Example:
 
 >>> import torch
@@ -101,8 +107,8 @@ def bellman_targets(
 ) -> TrainingData:
     """Computes Bellman targets for given states with a target model.
 
-    The target of a state is one more than the smallest estimated distance of its children, and 0 for the central state
-    (see the module docstring). For a Q-model, whose outputs are estimated distances of the children themselves, the
+    The target of a state is one more than the smallest estimated distance of its children, and 0 for the central state.
+    For a Q-model, whose outputs are estimated distances of the children themselves, the
     target of output ``a`` is the estimated distance of ``child_a(s)`` - so unlike targets from a random walk (see
     :class:`cayleypy.train.SparseQSampler`), all outputs are labeled.
 
@@ -203,14 +209,16 @@ class BellmanTargets(DataSource):
 
     def _frozen_copy(self, model: TargetModel) -> Predictor:
         """Copies the given model and makes it usable for computing targets only."""
-        # A Predictor holds the graph, which is not what is being copied here (and copying it would duplicate the
-        # generators and the hasher on the device), so only the model inside it is taken.
-        target = copy.deepcopy(model.predict if isinstance(model, Predictor) else model)
-        if isinstance(target, nn.Module):
-            target.eval()
-            for parameter in target.parameters():
-                parameter.requires_grad_(False)
-        return Predictor(self.graph, target)
+        # The graph is shared rather than copied: it is not what is being frozen here, and copying it would duplicate
+        # the generators and the hasher on the device. Seeding the memo with it is what makes deepcopy share it - which
+        # matters for a Predictor (and for an ensemble of them), because a Predictor holds the graph.
+        target = copy.deepcopy(model, {id(self.graph): self.graph})
+        inner = target.predict if isinstance(target, Predictor) else target
+        if isinstance(inner, nn.Module):
+            inner.eval()
+            inner.requires_grad_(False)
+        # A Predictor is returned as it is, so that a predictor which scores children itself keeps doing that.
+        return target if isinstance(target, Predictor) else Predictor(self.graph, target)
 
 
 class BellmanTrainer(Trainer):
@@ -234,6 +242,8 @@ class BellmanTrainer(Trainer):
     distance - and the reason to do it is that the estimates are loose exactly where beam search spends its time.
     Fine-tuning starts from a checkpoint (:meth:`from_checkpoint`) with a learning rate lower than the one used for
     pretraining: targets move as the model moves, and a large step in that feedback loop makes training oscillate.
+
+    Generators must be inverse closed (see the module docstring).
 
     Q-models (one output per generator) are trained here as well, and get more out of it than models with one output: a
     random walk labels two outputs of a state (see :class:`cayleypy.train.SparseQSampler`), while Bellman targets label
@@ -270,6 +280,13 @@ class BellmanTrainer(Trainer):
         :param states_source: Where to take states to compute targets for (optional). Defaults to random walks
             described by `config`. Its targets are ignored - only states are used.
         """
+        if not graph.definition.generators_inverse_closed:
+            # Bellman targets are the distance to the central state, the mandatory anchors are the distance from it.
+            raise ValueError(
+                "BellmanTrainer requires inverse-closed generators (for every generator, its inverse must also be a "
+                "generator), because its targets measure the distance to the central state while the anchors it mixes "
+                "them with measure the distance from it. Train on CayleyGraph.with_inverted_generators instead."
+            )
         self._states_source = states_source
         super().__init__(graph, model_config, config=config, model=model)
 

--- a/cayleypy/train/bellman.py
+++ b/cayleypy/train/bellman.py
@@ -73,8 +73,11 @@ def _values(graph: "CayleyGraph", target: Predictor, encoded_states: torch.Tenso
     :param encoded_states: States in internal representation.
     :return: Tensor of shape ``[n_states]`` with estimated distances.
     """
+    states = graph.decode_states(encoded_states)
     with torch.no_grad():
-        output = target.predict_batched(graph.decode_states(encoded_states))
+        # A Q-model, and any predictor wrapping one (an ensemble, or test-time augmentation), gives its outputs through
+        # score_children - unlike `predict_batched`, which those wrappers can only implement for one score per state.
+        output = target.score_children(states) if target.n_outputs != 1 else target.predict_batched(states)
     if output.dim() == 2:
         n_generators = graph.definition.n_generators
         if output.shape[1] != n_generators:

--- a/cayleypy/train/bellman.py
+++ b/cayleypy/train/bellman.py
@@ -39,7 +39,7 @@ import torch
 from torch import nn
 
 from .config import TrainConfig
-from .data import BfsAnchors, DataSource, MixtureDataSource, RandomWalksSource, TrainingData
+from .data import BfsAnchors, DataSource, RandomWalksSource, TrainingData
 from .trainer import Trainer
 from ..predictor import Predictor
 
@@ -221,6 +221,39 @@ class BellmanTargets(DataSource):
         return target if isinstance(target, Predictor) else Predictor(self.graph, target)
 
 
+class _BellmanWithAnchors(DataSource):
+    """Bellman targets with a share of anchors sized from the states that were actually generated.
+
+    The size of an epoch is not known before it is generated, because the source of states is arbitrary - it can be a
+    source the caller passed to :class:`BellmanTrainer`. Sizing the anchors in advance from `n_walks` and `rw_length`
+    and mixing with :class:`cayleypy.train.MixtureDataSource` would cut a source that generates more states than that
+    down to what the anchors can support, so most of what it generated would never be trained on. Here the anchors are
+    sized from the data instead, and nothing is thrown away - they are sampled with repetitions, so any number of them
+    can be asked for.
+    """
+
+    def __init__(self, bellman_source: BellmanTargets, anchors: BfsAnchors, anchors_fraction: float):
+        """Initializes _BellmanWithAnchors.
+
+        :param bellman_source: Source of states with bootstrapped targets.
+        :param anchors: Anchors to mix in. Their `size` is set on every call to :meth:`generate`.
+        :param anchors_fraction: Share of anchors in the generated data.
+        """
+        self.bellman_source = bellman_source
+        self.anchors = anchors
+        self.anchors_fraction = anchors_fraction
+
+    def generate(self) -> TrainingData:
+        """Generates Bellman targets and adds the anchors' share of them.
+
+        :return: Bellman targets and anchors, in one piece.
+        """
+        data = self.bellman_source.generate()
+        fraction = self.anchors_fraction
+        self.anchors.size = max(1, int(round(fraction / (1 - fraction) * len(data))))
+        return TrainingData.concat([data, self.anchors.generate()])
+
+
 class BellmanTrainer(Trainer):
     """Trains a model on Bellman targets, refreshing the target as training goes (the DAVI algorithm).
 
@@ -306,12 +339,10 @@ class BellmanTrainer(Trainer):
         # The model itself is the first target: the EMA copy does not exist yet (it is created after the data source)
         # and it starts as a copy of the model anyway.
         self.bellman_source = BellmanTargets(self.graph, states_source, self.model, n_outputs=n_outputs)
-        # Anchors sample exactly their share of what the states source generates, so the mixture has nothing to throw
-        # away. There are few states with exact distances near the central state, so they are sampled with repetitions.
-        fraction = config.anchors_fraction
-        size = max(1, int(round(fraction / (1 - fraction) * config.n_walks * config.rw_length)))
-        anchors = BfsAnchors(self.graph, depth=config.bellman_anchors_depth, size=size, n_outputs=n_outputs)
-        return MixtureDataSource([self.bellman_source, anchors], [1 - fraction, fraction])
+        # The anchors are sized when data is generated, from the number of states the source actually produced - see
+        # _BellmanWithAnchors for why that cannot be decided here.
+        anchors = BfsAnchors(self.graph, depth=config.bellman_anchors_depth, n_outputs=n_outputs)
+        return _BellmanWithAnchors(self.bellman_source, anchors, config.anchors_fraction)
 
     def train_epoch(self) -> float:
         """Refreshes the target if it is due, then generates data for one epoch and makes one pass over it.

--- a/cayleypy/train/bellman_test.py
+++ b/cayleypy/train/bellman_test.py
@@ -479,3 +479,24 @@ def test_bellman_training_from_scratch_learns_exact_distances():
     # Predicting the mean distance for every state would give an error of 1.47 on this graph.
     assert _mean_absolute_error(graph, trainer.predictor()) < 0.5
     assert abs(_prediction_at_central_state(graph, trainer.predictor())) < 0.3
+
+
+def test_bellman_trainer_honors_the_walk_mode_for_a_q_model():
+    """Test that walks are generated in the configured mode for a Q-model too (unlike in `Trainer`)."""
+    graph = _lrx5()
+    config = TrainConfig(n_epochs=1, n_walks=4, rw_length=3, batch_size=8, rw_mode="bfs", seed=0)
+
+    trainer = BellmanTrainer(graph, Q_CONFIG, config, model=_QModel())
+
+    states_source = trainer.bellman_source.states_source
+    assert isinstance(states_source, RandomWalksSource)
+    assert states_source.mode == "bfs"
+
+
+def test_bellman_trainer_rejects_graph_without_inverse_closed_generators():
+    """Test that a graph whose distances go one way only is rejected, instead of training on mixed directions."""
+    graph = CayleyGraph(PermutationGroups.lx(5), device="cpu")
+    model_config = ModelConfig(model_type="MLP", input_size=5, num_classes_for_one_hot=5, layers_sizes=[8])
+
+    with pytest.raises(ValueError, match="inverse-closed generators"):
+        BellmanTrainer(graph, model_config, TrainConfig(n_epochs=1, n_walks=4, rw_length=3))

--- a/cayleypy/train/bellman_test.py
+++ b/cayleypy/train/bellman_test.py
@@ -1,0 +1,457 @@
+import os
+
+import pytest
+import torch
+
+from .bellman import BellmanTargets, BellmanTrainer, bellman_targets
+from .config import TrainConfig
+from .data import BfsAnchors, DataSource, MixtureDataSource, RandomWalksSource, TrainingData
+from .trainer import Trainer
+from ..cayley_graph import CayleyGraph
+from ..graphs_lib import PermutationGroups
+from ..models.models import ModelConfig
+from ..predictor import Predictor
+
+RUN_SLOW_TESTS = os.getenv("RUN_SLOW_TESTS") == "1"
+
+MLP_CONFIG = ModelConfig(model_type="MLP", input_size=5, num_classes_for_one_hot=5, layers_sizes=[16, 16])
+
+# Config of a Q-model for lrx(5) - one output per generator. Architectures with several outputs are added in another
+# change, so tests below train the model defined here instead of building one from this config.
+Q_CONFIG = ModelConfig(model_type="MLP", input_size=5, num_classes_for_one_hot=5, layers_sizes=[16], n_outputs=3)
+
+# Configuration making training as short as possible - for tests that check mechanics rather than model quality.
+TINY_CONFIG = TrainConfig(n_epochs=2, n_walks=4, rw_length=3, batch_size=8, seed=0)
+
+
+def _lrx5() -> CayleyGraph:
+    return CayleyGraph(PermutationGroups.lrx(5), device="cpu")
+
+
+def _all_states_with_distances(graph: CayleyGraph) -> tuple[torch.Tensor, torch.Tensor]:
+    """Returns all states of the graph with their true distances, computed by exact BFS."""
+    layers = graph.bfs(max_layer_size_to_store=None).layers
+    states = torch.vstack([torch.as_tensor(layer) for layer in layers.values()])
+    distances = torch.hstack([torch.full((len(layer),), float(distance)) for distance, layer in layers.items()])
+    return states, distances
+
+
+def _keys(states: torch.Tensor) -> torch.Tensor:
+    """Maps states of a permutation group to unique integers, so that they can be looked up in a table."""
+    base = states.shape[1]
+    powers = base ** torch.arange(base, dtype=torch.int64)
+    return (states.to(torch.int64) * powers).sum(dim=1)
+
+
+class _TableModel(torch.nn.Module):
+    """Model that looks up the value of a state in a table, e.g. an oracle knowing exact distances."""
+
+    def __init__(self, states: torch.Tensor, values: torch.Tensor):
+        super().__init__()
+        keys = _keys(states)
+        order = torch.argsort(keys)
+        self.keys = keys[order]
+        self.values = values[order]
+
+    def forward(self, states: torch.Tensor) -> torch.Tensor:
+        keys = _keys(states)
+        index = torch.searchsorted(self.keys, keys)
+        assert bool((self.keys[index] == keys).all()), "Table has no value for some of these states."
+        return self.values[index]
+
+
+class _ConstantModel(torch.nn.Module):
+    """Model predicting the same value for every state, with a weight so that training can change it."""
+
+    def __init__(self, value: float, n_outputs: int = 1):
+        super().__init__()
+        self.n_outputs = n_outputs
+        self.value = torch.nn.Parameter(torch.full((n_outputs,), float(value)))
+
+    def forward(self, states: torch.Tensor) -> torch.Tensor:
+        answer = self.value.expand(states.shape[0], self.n_outputs)
+        return answer if self.n_outputs > 1 else answer.reshape(-1)
+
+
+class _QModel(torch.nn.Module):
+    """Minimal model with one output per generator, standing in for a Q-model architecture."""
+
+    def __init__(self, state_size: int = 5, n_outputs: int = 3):
+        super().__init__()
+        self.n_outputs = n_outputs
+        self.layer = torch.nn.Linear(state_size, n_outputs)
+
+    def forward(self, states: torch.Tensor) -> torch.Tensor:
+        return self.layer(states.to(torch.float32))
+
+
+class _FixedStates(DataSource):
+    """Data source always returning the same states (their targets are ignored by BellmanTargets)."""
+
+    def __init__(self, states: torch.Tensor):
+        self.states = states
+
+    def generate(self) -> TrainingData:
+        return TrainingData(states=self.states, targets=torch.zeros((self.states.shape[0],)))
+
+
+def _exact_q_values(graph: CayleyGraph, states: torch.Tensor, oracle: _TableModel) -> torch.Tensor:
+    """Returns exact distances of all children of given states, of shape ``[n_states, n_generators]``."""
+    columns = [oracle(graph.apply_path(states, [i])) for i in range(graph.definition.n_generators)]
+    return torch.stack(columns, dim=1)
+
+
+def test_bellman_targets_are_exact_distances_when_the_target_model_is_exact():
+    # The Bellman operator has exact distances as a fixed point: d(s) = 1 + min over children of d.
+    graph = _lrx5()
+    states, distances = _all_states_with_distances(graph)
+    data = bellman_targets(graph, states, _TableModel(states, distances))
+    assert torch.equal(data.targets, distances)
+    assert data.mask is None and data.weights is None
+
+
+def test_bellman_targets_for_q_model_are_exact_distances_of_children():
+    graph = _lrx5()
+    states, distances = _all_states_with_distances(graph)
+    oracle = _TableModel(states, distances)
+    q_values = _exact_q_values(graph, states, oracle)
+
+    # A Q-model knowing exact distances of children is a fixed point too.
+    data = bellman_targets(graph, states, _TableModel(states, q_values), n_outputs=3)
+    assert data.targets.shape == (120, 3)
+    assert torch.equal(data.targets, q_values)
+    # Column by column, because comparing whole tensors would not notice generators being transposed.
+    for gen_id in range(3):
+        assert torch.equal(data.targets[:, gen_id], oracle(graph.apply_path(states, [gen_id])))
+
+
+def test_bellman_targets_for_q_model_can_come_from_a_model_with_one_output():
+    # Targets of a Q-model are estimated distances of children, and any model can estimate those.
+    graph = _lrx5()
+    states, distances = _all_states_with_distances(graph)
+    oracle = _TableModel(states, distances)
+    data = bellman_targets(graph, states, oracle, n_outputs=3)
+    assert torch.equal(data.targets, _exact_q_values(graph, states, oracle))
+
+
+def test_bellman_targets_pin_the_central_state_and_its_neighbors():
+    graph = _lrx5()
+    central = graph.central_state.reshape(1, -1)
+    neighbor = graph.apply_path(central, [2])
+    far_state = graph.apply_path(central, [2, 0])
+    states = torch.vstack([central, neighbor, far_state])
+
+    targets = bellman_targets(graph, states, _ConstantModel(100.0)).targets
+    # The distance of the central state is known, so it is 0 and the state next to it is 1, whatever the model says.
+    assert float(targets[0]) == 0.0
+    assert float(targets[1]) == 1.0
+    assert float(targets[2]) == 101.0
+
+
+def test_bellman_targets_clamp_negative_estimates():
+    graph = _lrx5()
+    states, _ = _all_states_with_distances(graph)
+    targets = bellman_targets(graph, states, _ConstantModel(-7.0)).targets
+    # Distances cannot be negative, so estimates are clamped at 0 and every state is "one move from something at 0".
+    assert torch.equal(targets, torch.where(_keys(states) == _keys(graph.central_state.reshape(1, -1)), 0.0, 1.0))
+
+
+def test_bellman_targets_use_the_nearest_child():
+    graph = _lrx5()
+    # A state 3 moves away, so that none of its children is the central state (whose estimate is pinned to 0).
+    state = graph.apply_path(graph.central_state.reshape(1, -1), [2, 0, 2])
+    children = graph.get_neighbors_decoded(state)
+    model = _TableModel(children, torch.tensor([7.0, 2.0, 5.0]))
+    assert float(bellman_targets(graph, state, model).targets[0]) == 3.0
+    # For a Q-model, every output gets the estimate for its own child instead.
+    assert torch.equal(bellman_targets(graph, state, model, n_outputs=3).targets, torch.tensor([[7.0, 2.0, 5.0]]))
+
+
+def test_bellman_targets_accept_a_predictor():
+    graph = _lrx5()
+    states, _ = _all_states_with_distances(graph)
+    from_predictor = bellman_targets(graph, states, Predictor(graph, "hamming")).targets
+    from_callable = bellman_targets(graph, states, lambda x: (x != graph.central_state).sum(dim=1)).targets
+    assert torch.equal(from_predictor, from_callable)
+    assert torch.all(from_predictor >= 0)
+
+
+def test_bellman_targets_split_large_input_into_batches():
+    # Children of these states do not fit in one batch, so the target model is applied several times.
+    graph = CayleyGraph(PermutationGroups.lrx(5), device="cpu", batch_size=7)
+    states, distances = _all_states_with_distances(graph)
+    assert torch.equal(bellman_targets(graph, states, _TableModel(states, distances)).targets, distances)
+
+
+def test_bellman_targets_accept_a_single_state():
+    graph = _lrx5()
+    data = bellman_targets(graph, graph.central_state, _ConstantModel(3.0))
+    assert data.states.shape == (1, 5)
+    assert torch.equal(data.targets, torch.zeros(1))
+
+
+def test_value_iteration_converges_to_exact_distances():
+    # Applying the operator to its own output propagates exact distances outwards from the central state, one layer of
+    # the graph per iteration - which is what training on Bellman targets does, with a model in between.
+    graph = _lrx5()
+    states, distances = _all_states_with_distances(graph)
+    values = torch.zeros(int(states.shape[0]))
+    diameter = int(distances.max())
+    for iteration in range(diameter):
+        values = bellman_targets(graph, states, _TableModel(states, values)).targets
+        # After k iterations, states at distance at most k have their exact distance, and the rest are underestimated.
+        assert torch.equal(values, distances.clamp(max=iteration + 1))
+    assert torch.equal(values, distances)
+
+
+def test_bellman_targets_source_labels_states_of_the_inner_source():
+    graph = _lrx5()
+    torch.manual_seed(0)
+    walks = RandomWalksSource(graph, n_walks=4, rw_length=5)
+    source = BellmanTargets(graph, walks, _ConstantModel(2.0))
+    data = source.generate()
+    assert len(data) == 20
+    assert data.targets.shape == (20,)
+    # Targets are recomputed from the model, whatever targets the inner source produced.
+    assert torch.equal(data.targets, bellman_targets(graph, data.states, _ConstantModel(2.0)).targets)
+
+
+def test_bellman_targets_source_freezes_the_target_model():
+    graph = _lrx5()
+    states, _ = _all_states_with_distances(graph)
+    model = _ConstantModel(2.0)
+    source = BellmanTargets(graph, _FixedStates(states), model)
+    before = source.generate().targets
+
+    with torch.no_grad():
+        model.value += 10.0
+    # Training the model does not change targets: the source holds a frozen copy of it.
+    assert torch.equal(source.generate().targets, before)
+
+    source.update_target(model)
+    after = source.generate().targets
+    assert not torch.equal(after, before)
+    assert torch.equal(after, bellman_targets(graph, states, model).targets)
+
+
+def test_bellman_targets_source_for_q_model():
+    graph = _lrx5()
+    states, _ = _all_states_with_distances(graph)
+    source = BellmanTargets(graph, _FixedStates(states), _QModel(), n_outputs=3)
+    data = source.generate()
+    assert data.targets.shape == (120, 3)
+    # Unlike targets from a random walk, all outputs are labeled.
+    assert data.mask is None
+
+
+def test_bellman_trainer_mixes_bellman_targets_with_anchors():
+    graph = _lrx5()
+    config = TrainConfig(n_epochs=1, n_walks=4, rw_length=5, batch_size=8, anchors_fraction=0.5, seed=0)
+    trainer = BellmanTrainer(graph, MLP_CONFIG, config)
+    source = trainer.data_source
+    assert isinstance(source, MixtureDataSource)
+    assert isinstance(source.sources[0], BellmanTargets)
+    assert isinstance(source.sources[1], BfsAnchors)
+    assert source.fractions == [0.5, 0.5]
+    assert source.sources[0] is trainer.bellman_source
+
+
+def test_bellman_trainer_anchors_have_exact_targets():
+    graph = _lrx5()
+    config = TrainConfig(n_epochs=1, n_walks=8, rw_length=5, anchors_fraction=0.5, bellman_anchors_depth=2, seed=0)
+    trainer = BellmanTrainer(graph, MLP_CONFIG, config, model=_ConstantModel(100.0))
+    data = trainer.generate_data()
+    # Walks give 8*5 states, and anchors are sampled to the same number, because they are half of the data.
+    assert len(data) == 80
+    # With a model predicting 100 everywhere, Bellman targets can only be 0, 1 or 101, so a target of 2 is a state
+    # whose distance the breadth-first search knows exactly.
+    assert int((data.targets == 2.0).sum()) > 0
+    n_exact = int(((data.targets != 0.0) & (data.targets != 1.0) & (data.targets != 101.0)).sum())
+    assert n_exact > 0.2 * len(data)
+
+
+def test_bellman_trainer_refreshes_the_target_every_epoch():
+    graph = _lrx5()
+    config = TrainConfig(n_epochs=3, n_walks=4, rw_length=5, batch_size=8, lr=0.05, ema_decay=0, seed=0)
+    trainer = BellmanTrainer(graph, MLP_CONFIG, config)
+    states, _ = _all_states_with_distances(graph)
+    for _ in range(config.n_epochs):
+        with torch.no_grad():
+            expected = trainer.predictor()(states).clone()
+        trainer.train_epoch()
+        with torch.no_grad():
+            # The target is the model as it was at the beginning of the epoch.
+            assert torch.equal(trainer.bellman_source.target(states), expected)
+            assert not torch.equal(trainer.predictor()(states), expected)
+
+
+def test_bellman_trainer_keeps_the_target_for_the_configured_number_of_epochs():
+    graph = _lrx5()
+    config = TrainConfig(
+        n_epochs=4, n_walks=4, rw_length=5, batch_size=8, lr=0.05, ema_decay=0, bellman_target_update_period=2, seed=0
+    )
+    trainer = BellmanTrainer(graph, MLP_CONFIG, config)
+    states, _ = _all_states_with_distances(graph)
+
+    trainer.train_epoch()
+    with torch.no_grad():
+        after_first_refresh = trainer.bellman_source.target(states).clone()
+    trainer.train_epoch()
+    with torch.no_grad():
+        # Second epoch does not refresh the target, so it is still the same.
+        assert torch.equal(trainer.bellman_source.target(states), after_first_refresh)
+        expected = trainer.predictor()(states).clone()
+    trainer.train_epoch()
+    with torch.no_grad():
+        # Third epoch refreshes it, to the weights the model had when that epoch started.
+        assert torch.equal(trainer.bellman_source.target(states), expected)
+
+
+def test_training_on_bellman_targets_reduces_the_loss():
+    graph = _lrx5()
+    trainer = BellmanTrainer(graph, MLP_CONFIG, TrainConfig(n_walks=8, rw_length=5, lr=0.01, seed=0))
+    data = trainer.generate_data()
+    first_loss = trainer.train_step(data.states, data.targets)
+    for _ in range(10):
+        last_loss = trainer.train_step(data.states, data.targets)
+    assert last_loss < first_loss
+
+
+def test_bellman_trainer_trains_a_q_model():
+    graph = _lrx5()
+    config = TrainConfig(n_epochs=2, n_walks=8, rw_length=5, batch_size=16, lr=0.01, seed=0)
+    trainer = BellmanTrainer(graph, Q_CONFIG, config, model=_QModel())
+    data = trainer.generate_data()
+    assert data.targets.shape[1] == 3
+    assert data.mask is None
+    result = trainer.train()
+    assert len(result.losses) == 2
+    with torch.no_grad():
+        assert trainer.predictor().predict_batched(data.states).shape == (len(data), 3)
+
+
+def test_bellman_trainer_from_checkpoint_continues_from_the_pretrained_model(tmp_path):
+    path = tmp_path / "pretrained.pt"
+    graph = _lrx5()
+    pretrained = Trainer(graph, MLP_CONFIG, TINY_CONFIG)
+    pretrained.train()
+    pretrained.save(path)
+
+    # Fine-tuning normally uses a lower learning rate than pretraining, because targets move as the model moves.
+    trainer = BellmanTrainer.from_checkpoint(path, graph, TrainConfig(n_epochs=1, n_walks=4, rw_length=3, lr=1e-4))
+    assert isinstance(trainer, BellmanTrainer)
+    states, _ = _all_states_with_distances(graph)
+    with torch.no_grad():
+        assert torch.equal(trainer.model(states), pretrained.ema_model(states))
+    trainer.train()
+    with torch.no_grad():
+        assert not torch.equal(trainer.model(states), pretrained.ema_model(states))
+
+
+def test_bellman_trainer_does_not_move_the_scale_without_optimization():
+    # Sanity check: bootstrapped targets by themselves change nothing - predictions only move when weights do.
+    graph = _lrx5()
+    config = TrainConfig(n_epochs=5, n_walks=8, rw_length=5, batch_size=16, lr=1e-12, seed=0)
+    trainer = BellmanTrainer(graph, MLP_CONFIG, config)
+    states, _ = _all_states_with_distances(graph)
+    with torch.no_grad():
+        before = trainer.predictor()(states).clone()
+    trainer.train()
+    with torch.no_grad():
+        assert torch.allclose(trainer.predictor()(states), before, atol=1e-5)
+
+
+def test_bellman_targets_reject_wrong_number_of_outputs():
+    graph = _lrx5()
+    states = graph.central_state.reshape(1, -1)
+    for n_outputs in (0, 2, 4):
+        with pytest.raises(ValueError, match="n_outputs must be either 1 or the number of generators"):
+            bellman_targets(graph, states, _ConstantModel(1.0), n_outputs=n_outputs)
+    with pytest.raises(ValueError, match="n_outputs must be either 1 or the number of generators"):
+        BellmanTargets(graph, _FixedStates(states), _ConstantModel(1.0), n_outputs=2)
+
+
+def test_bellman_targets_reject_target_model_with_unexpected_output_shape():
+    graph = _lrx5()
+    states = graph.central_state.reshape(1, -1)
+
+    def model(x: torch.Tensor) -> torch.Tensor:
+        return torch.zeros((x.shape[0], 3, 2))
+
+    with pytest.raises(ValueError, match="one score per state .1-D output. or one score per generator"):
+        bellman_targets(graph, states, model)
+
+
+def test_train_config_rejects_invalid_bellman_values():
+    with pytest.raises(ValueError, match="bellman_anchors_depth must be at least 1"):
+        TrainConfig(bellman_anchors_depth=0)
+    with pytest.raises(ValueError, match="bellman_anchors_depth must be at least 1"):
+        TrainConfig(bellman_anchors_depth=-1)
+    with pytest.raises(ValueError, match="bellman_target_update_period must be positive"):
+        TrainConfig(bellman_target_update_period=0)
+
+
+def test_bellman_trainer_rejects_checkpoint_for_another_graph(tmp_path):
+    path = tmp_path / "model.pt"
+    Trainer(_lrx5(), MLP_CONFIG, TINY_CONFIG).save(path)
+    another_graph = CayleyGraph(PermutationGroups.lrx(5, k=2), device="cpu")
+    with pytest.raises(ValueError, match="was trained for another graph"):
+        BellmanTrainer.from_checkpoint(path, another_graph, TINY_CONFIG)
+
+
+def test_bellman_trainer_rejects_model_with_wrong_number_of_outputs():
+    config = ModelConfig(model_type="MLP", input_size=5, num_classes_for_one_hot=5, layers_sizes=[16], n_outputs=4)
+    with pytest.raises(ValueError, match="one output per generator of this graph, of which there are 3"):
+        BellmanTrainer(_lrx5(), config, TINY_CONFIG, model=_QModel(n_outputs=4))
+
+
+def _mean_absolute_error(graph: CayleyGraph, predictor: Predictor) -> float:
+    """Mean absolute error of the predictor on all states of the graph, against exact distances."""
+    states, distances = _all_states_with_distances(graph)
+    with torch.no_grad():
+        return float((predictor(states) - distances).abs().mean())
+
+
+def _prediction_at_central_state(graph: CayleyGraph, predictor: Predictor) -> float:
+    with torch.no_grad():
+        return float(predictor(graph.central_state.reshape(1, -1))[0])
+
+
+@pytest.mark.skipif(not RUN_SLOW_TESTS, reason="Slow test.")
+def test_bellman_finetuning_improves_a_pretrained_model(tmp_path):
+    # Random walks label a state with the number of steps at which they visited it, which overestimates its distance.
+    # Bellman targets do not have this bias, so fine-tuning on them moves predictions towards the exact distances.
+    graph = _lrx5()
+    path = tmp_path / "pretrained.pt"
+    pretrain_config = TrainConfig(n_epochs=100, n_walks=64, rw_length=12, batch_size=128, lr=0.01, seed=42)
+    pretrained = Trainer(graph, MLP_CONFIG, pretrain_config)
+    pretrained.train()
+    pretrained.save(path)
+    error_before = _mean_absolute_error(graph, pretrained.predictor())
+    # Walks even overestimate the distance of the central state, which they visit at every step of every walk.
+    assert abs(_prediction_at_central_state(graph, pretrained.predictor())) > 1.0
+
+    finetune_config = TrainConfig(
+        n_epochs=100, n_walks=64, rw_length=12, batch_size=128, lr=0.001, bellman_anchors_depth=2, seed=42
+    )
+    finetuned = BellmanTrainer.from_checkpoint(path, graph, finetune_config)
+    finetuned.train()
+    error_after = _mean_absolute_error(graph, finetuned.predictor())
+    assert error_after < 0.7 * error_before
+    assert abs(_prediction_at_central_state(graph, finetuned.predictor())) < 0.5
+
+
+@pytest.mark.skipif(not RUN_SLOW_TESTS, reason="Slow test.")
+def test_bellman_training_from_scratch_learns_exact_distances():
+    # Value iteration works without any pretraining at all: exact distances spread from the central state, and on a
+    # graph small enough for the model to fit all of it, predictions end up close to the distances from exact BFS.
+    graph = _lrx5()
+    model_config = ModelConfig(model_type="MLP", input_size=5, num_classes_for_one_hot=5, layers_sizes=[64, 64])
+    config = TrainConfig(
+        n_epochs=200, n_walks=64, rw_length=12, batch_size=128, lr=0.01, bellman_anchors_depth=2, seed=0
+    )
+    trainer = BellmanTrainer(graph, model_config, config)
+    trainer.train()
+    # Predicting the mean distance for every state would give an error of 1.47 on this graph.
+    assert _mean_absolute_error(graph, trainer.predictor()) < 0.5
+    assert abs(_prediction_at_central_state(graph, trainer.predictor())) < 0.3

--- a/cayleypy/train/bellman_test.py
+++ b/cayleypy/train/bellman_test.py
@@ -176,6 +176,30 @@ def test_bellman_targets_accept_a_predictor():
     assert torch.all(from_predictor >= 0)
 
 
+def test_bellman_targets_reject_target_scoring_a_wrong_number_of_children():
+    graph = _lrx5()
+    # Two scores per state, while a model estimating distances of children of this graph must return three.
+    target = _ConstantModel(1.0, n_outputs=2)
+    with pytest.raises(ValueError, match="one score per generator"):
+        bellman_targets(graph, graph.central_state.reshape(1, -1), target)
+
+
+def test_target_given_as_predictor_is_frozen_and_does_not_copy_the_graph():
+    graph = _lrx5()
+    model = _QModel()
+    for parameter in model.parameters():
+        parameter.requires_grad_(True)
+
+    source = BellmanTargets(graph, _FixedStates(graph.central_state.reshape(1, -1)), Predictor(graph, model), 3)
+
+    assert source.target.graph is graph
+    frozen = source.target.predict
+    assert isinstance(frozen, torch.nn.Module)
+    assert frozen is not model
+    assert not frozen.training
+    assert all(not parameter.requires_grad for parameter in frozen.parameters())
+
+
 def test_bellman_targets_split_large_input_into_batches():
     # Children of these states do not fit in one batch, so the target model is applied several times.
     graph = CayleyGraph(PermutationGroups.lrx(5), device="cpu", batch_size=7)

--- a/cayleypy/train/bellman_test.py
+++ b/cayleypy/train/bellman_test.py
@@ -178,10 +178,19 @@ def test_bellman_targets_accept_a_predictor():
 
 def test_bellman_targets_reject_target_scoring_a_wrong_number_of_children():
     graph = _lrx5()
+    central_state = graph.central_state.reshape(1, -1)
+
     # Two scores per state, while a model estimating distances of children of this graph must return three.
     target = _ConstantModel(1.0, n_outputs=2)
+    with pytest.raises(ValueError, match="2 outputs, but the graph has 3 generators"):
+        bellman_targets(graph, central_state, target)
+
+    # The same, from a model that does not say how many outputs it has - the width of what it returns is still checked.
+    def undeclared_target(states: torch.Tensor) -> torch.Tensor:
+        return torch.ones((states.shape[0], 2))
+
     with pytest.raises(ValueError, match="one score per generator"):
-        bellman_targets(graph, graph.central_state.reshape(1, -1), target)
+        bellman_targets(graph, central_state, undeclared_target)
 
 
 def test_target_given_as_predictor_is_frozen_and_does_not_copy_the_graph():

--- a/cayleypy/train/bellman_test.py
+++ b/cayleypy/train/bellman_test.py
@@ -3,9 +3,9 @@ import os
 import pytest
 import torch
 
-from .bellman import BellmanTargets, BellmanTrainer, bellman_targets
+from .bellman import BellmanTargets, BellmanTrainer, _BellmanWithAnchors, bellman_targets
 from .config import TrainConfig
-from .data import BfsAnchors, DataSource, MixtureDataSource, RandomWalksSource, TrainingData
+from .data import BfsAnchors, DataSource, RandomWalksSource, TrainingData
 from .trainer import Trainer
 from ..cayley_graph import CayleyGraph
 from ..graphs_lib import PermutationGroups
@@ -273,11 +273,35 @@ def test_bellman_trainer_mixes_bellman_targets_with_anchors():
     config = TrainConfig(n_epochs=1, n_walks=4, rw_length=5, batch_size=8, anchors_fraction=0.5, seed=0)
     trainer = BellmanTrainer(graph, MLP_CONFIG, config)
     source = trainer.data_source
-    assert isinstance(source, MixtureDataSource)
-    assert isinstance(source.sources[0], BellmanTargets)
-    assert isinstance(source.sources[1], BfsAnchors)
-    assert source.fractions == [0.5, 0.5]
-    assert source.sources[0] is trainer.bellman_source
+    assert isinstance(source, _BellmanWithAnchors)
+    assert isinstance(source.bellman_source, BellmanTargets)
+    assert isinstance(source.anchors, BfsAnchors)
+    assert source.anchors_fraction == 0.5
+    assert source.bellman_source is trainer.bellman_source
+
+
+class _FixedStatesSource(DataSource):
+    """Source generating a fixed number of states, unrelated to any `n_walks` and `rw_length`."""
+
+    def __init__(self, graph: CayleyGraph, size: int):
+        self.graph = graph
+        self.size = size
+
+    def generate(self) -> TrainingData:
+        states = self.graph.random_walks(width=self.size, length=2)[0][: self.size]
+        return TrainingData(states=states, targets=torch.zeros(self.size))
+
+
+def test_bellman_trainer_sizes_anchors_from_a_custom_states_source():
+    graph = _lrx5()
+    # The config says 4*3=12 states per epoch, but the source generates 120. Sizing the anchors from the config would
+    # leave them able to support only 50 states, and all but 49 of the source's states would be thrown away.
+    config = TrainConfig(n_epochs=1, n_walks=4, rw_length=3, anchors_fraction=0.02, seed=0)
+    trainer = BellmanTrainer(graph, MLP_CONFIG, config, states_source=_FixedStatesSource(graph, 120))
+    data = trainer.generate_data()
+    # Every state of the source is kept, and 2% of the epoch on top of them are anchors.
+    assert len(data) == 122
+    assert trainer.data_source.anchors.size == 2
 
 
 def test_bellman_trainer_anchors_have_exact_targets():

--- a/cayleypy/train/config.py
+++ b/cayleypy/train/config.py
@@ -31,18 +31,20 @@ class TrainConfig:
     :param rw_length: Length of every random walk. Must be at least 2. Should be at least as large as the diameter of
         the graph, otherwise the model never sees distant states.
     :param rw_mode: Mode of random walk generation - one of "classic", "bfs", "nbt". Defaults to "nbt", which mixes
-        fastest, meaning the number of steps is the closest estimate of the true distance. Ignored when training a
-        Q-model: its data comes from :class:`cayleypy.train.SparseQSampler`, which needs walks to be paths and
-        therefore always uses "classic" walks.
+        fastest, meaning the number of steps is the closest estimate of the true distance. Ignored by
+        :class:`cayleypy.train.Trainer` when training a Q-model: its data comes from
+        :class:`cayleypy.train.SparseQSampler`, which needs walks to be paths and therefore always uses "classic" walks.
+        :class:`cayleypy.train.BellmanTrainer` honors it for Q-models too, because Bellman targets label every output of
+        a state and so do not need walks to be paths.
     :param nbt_history_depth: For "nbt" mode, how many previous levels to remember and ban from revisiting.
     :param anchors_depth: Depth of the breadth-first search producing anchors - states with exact distances that are
         mixed into the data, see :class:`cayleypy.train.BfsAnchors`. 0 (the default) means no anchors. Note that memory
         needed for the search grows quickly with this depth.
     :param anchors_fraction: Share of anchors in the data of one epoch (ignored if `anchors_depth` is 0, but still
-        required to be strictly between 0 and 1 - to train without anchors, leave `anchors_depth` at 0 and this field at
-        its default; :class:`cayleypy.train.BellmanTrainer` always uses it, because anchors are mandatory there). A few
-        per cent is what helps; a large share (10% and more, empirically) makes the model good near the central state and
-        worse where beam search actually spends its time.
+        required to be strictly between 0 and 1 - to train without anchors, leave `anchors_depth` at 0 and this field
+        at its default; :class:`cayleypy.train.BellmanTrainer` always uses it, because anchors are mandatory there). A
+        few per cent is what helps; a large share (10% and more, empirically) makes the model good near the central
+        state and worse where beam search actually spends its time.
     :param bellman_anchors_depth: Depth of the breadth-first search producing anchors for
         :class:`cayleypy.train.BellmanTrainer`, which needs them (unlike the walk-based trainer, where `anchors_depth`
         is 0 by default): bootstrapped targets only say how far states are from each other, so without exactly known

--- a/cayleypy/train/config.py
+++ b/cayleypy/train/config.py
@@ -38,9 +38,19 @@ class TrainConfig:
     :param anchors_depth: Depth of the breadth-first search producing anchors - states with exact distances that are
         mixed into the data, see :class:`cayleypy.train.BfsAnchors`. 0 (the default) means no anchors. Note that memory
         needed for the search grows quickly with this depth.
-    :param anchors_fraction: Share of anchors in the data of one epoch (ignored if `anchors_depth` is 0). A few per cent
-        is what helps; a large share (10% and more, empirically) makes the model good near the central state and worse
-        where beam search actually spends its time.
+    :param anchors_fraction: Share of anchors in the data of one epoch (ignored if `anchors_depth` is 0, and always used
+        by :class:`cayleypy.train.BellmanTrainer`, where anchors are mandatory). A few per cent is what helps; a large
+        share (10% and more, empirically) makes the model good near the central state and worse where beam search
+        actually spends its time.
+    :param bellman_anchors_depth: Depth of the breadth-first search producing anchors for
+        :class:`cayleypy.train.BellmanTrainer`, which needs them (unlike the walk-based trainer, where `anchors_depth`
+        is 0 by default): bootstrapped targets only say how far states are from each other, so without exactly known
+        distances the scale of the predictions drifts. Must be at least 1, which means the central state and its
+        neighbors. Ignored when training on walk targets.
+    :param bellman_target_update_period: How many epochs :class:`cayleypy.train.BellmanTrainer` keeps the target (the
+        frozen copy of the model that computes targets) before refreshing it from the model being trained. 1 (the
+        default) means the target is the EMA copy of the weights, which lags behind by design; a larger value holds it
+        fixed for several epochs instead. Ignored when training on walk targets.
     :param batch_size: Number of states in one training batch.
     :param lr: Initial learning rate.
     :param lr_min: Learning rate at the end of training. The learning rate follows a cosine schedule from `lr` to
@@ -61,6 +71,8 @@ class TrainConfig:
     nbt_history_depth: int = 1
     anchors_depth: int = 0
     anchors_fraction: float = 0.02
+    bellman_anchors_depth: int = 1
+    bellman_target_update_period: int = 1
     batch_size: int = 512
     lr: float = 1e-3
     lr_min: float = 0.0
@@ -86,6 +98,13 @@ class TrainConfig:
             raise ValueError(f"anchors_depth must be non-negative, got {self.anchors_depth}.")
         if not 0.0 < self.anchors_fraction < 1.0:
             raise ValueError(f"anchors_fraction must be strictly between 0 and 1, got {self.anchors_fraction}.")
+        if self.bellman_anchors_depth < 1:
+            raise ValueError(
+                f"bellman_anchors_depth must be at least 1, got {self.bellman_anchors_depth}. Bellman targets are "
+                "bootstrapped from the model itself, so anchors with exactly known distances are what keeps the scale "
+                "of the predictions from drifting, and cannot be turned off."
+            )
+        _check_positive("bellman_target_update_period", self.bellman_target_update_period)
         if not 0.0 <= self.lr_min <= self.lr:
             raise ValueError(f"lr_min must be between 0 and lr={self.lr}, got {self.lr_min}.")
         if self.weight_decay < 0:

--- a/cayleypy/train/trainer.py
+++ b/cayleypy/train/trainer.py
@@ -133,8 +133,9 @@ class Trainer:
         self.epoch = 0
         self.n_steps = 0
 
-    @staticmethod
+    @classmethod
     def from_checkpoint(
+        cls,
         path: PathType,
         graph: "CayleyGraph",
         config: Optional[TrainConfig] = None,
@@ -144,6 +145,9 @@ class Trainer:
         Only weights are stored in checkpoints, so the optimizer, the learning rate schedule and the EMA copy start
         anew (the EMA copy starts from the weights that were loaded).
 
+        Subclasses of the trainer are created as well, so this is also the way to fine-tune a pretrained model with
+        another training scheme, e.g. :meth:`cayleypy.train.BellmanTrainer.from_checkpoint`.
+
         :param path: Path to a checkpoint written by :func:`cayleypy.models.save_checkpoint` (e.g. by :meth:`save`).
         :param graph: Graph for which to continue training. If the checkpoint says which graph the model was trained
             for, it must be this graph.
@@ -151,7 +155,7 @@ class Trainer:
         :return: The trainer.
         """
         model, model_config = load_checkpoint(path, device=str(graph.device), graph_def=graph.definition)
-        return Trainer(graph, model_config, config=config, model=model)
+        return cls(graph, model_config, config=config, model=model)
 
     @property
     def learning_rate(self) -> float:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -68,6 +68,9 @@ Training
     cayleypy.train.BfsAnchors
     cayleypy.train.PathDataSource
     cayleypy.train.MixtureDataSource
+    cayleypy.train.bellman_targets
+    cayleypy.train.BellmanTargets
+    cayleypy.train.BellmanTrainer
 
 BFS algorithm and its variations
 ''''''''''''''''''''''''''''''''


### PR DESCRIPTION
Bellman (DAVI) fine-tuning: targets computed from the model itself instead of from the number of steps of a random walk.

A random walk labels a state with the step at which it visited that state, which is an upper estimate of the distance - and a loose one exactly where beam search spends its time. This PR adds the other source of targets: a state is one move away from its children, so a frozen copy of the model applied to the children says what the model should predict for the state:

```
y(s) = 0                              if s is the central state,
y(s) = 1 + min_a V_target(child_a(s)) otherwise.
```

## What is in it

- **`bellman_targets(graph, states, target, n_outputs)`** — the operator, one batched pass over all children. The estimate of the central state is 0 whatever the model says and estimates are clamped at 0, so the target of every state next to the goal is exactly 1 — this is what makes value iteration start, and exact distances are a fixed point of the operator (tested against full BFS on `lrx(5)`, column by column for Q-models). A Q-model gets a target for **every** output, while a random walk labels two of them (`SparseQSampler`), and it does not need walks to be paths, so `rw_mode` (including `"nbt"`) is honored for Q-models too.
- **`BellmanTargets`** — a `DataSource` that takes states from any other source (random walks by default) and labels them with a frozen copy of the model. `update_target(model)` moves the target forward; until then, training does not change targets.
- **`BellmanTrainer`** — `Trainer` whose epoch data is Bellman targets on walks **mixed with anchors**. Anchors are mandatory here (`TrainConfig.bellman_anchors_depth`, at least 1 = the central state and its neighbors): bootstrapped targets only say how far states are from each other, and without exactly known distances the whole scale drifts. The target is refreshed from the EMA copy of the weights every `TrainConfig.bellman_target_update_period` epochs — 1 (the default) makes the target the EMA copy, which lags by design; a larger value holds it fixed for several epochs.
- **`Trainer.from_checkpoint` is now a `classmethod`** (➕ small scope addition), so `BellmanTrainer.from_checkpoint(path, graph, config)` is the fine-tuning entry point: start from a random-walk pretrain (the self-describing checkpoint of #1) with a lower learning rate, because targets move as the model moves.

## Numbers (`lrx(5)`, exact BFS as ground truth, seed 42)

| | mean absolute error | prediction at the central state |
|---|---|---|
| random-walk pretrain (100 epochs) | 2.27 | 2.46 |
| after Bellman fine-tuning (100 epochs, lr ÷ 10) | **0.95** | **0.01** |
| Bellman from scratch (200 epochs, `[64, 64]`) | **0.06** | 0.00 |

Predicting the mean distance for every state gives an error of 1.47, so the pretrain on walk targets is barely better than that and the fine-tune is an order of magnitude better. The prediction at the central state shows where the bias comes from: walks visit it at step 0 of every walk *and* label it 0 only there, while `nbt` walks that come back to it label it with the step number.

## Relation to the rest of the series

This is the answer to the limit found in #11: the `lrx-20` demo model plateaus after a few epochs not because of the budget but because of the labels (the step index of a "classic" walk). Bellman targets and `PathDataSource` are the two ways past it — retraining `lrx-18`/`lrx-20` with this is tracked in the plan's manual-verification list.

Q-models are trained here (`BellmanTrainer` accepts them and produces dense targets), but a multi-output architecture to demonstrate it end-to-end comes from #3, so the tests here use the same minimal stand-in Q-model as #9/#10.

## Tests

28 new tests in `cayleypy/train/bellman_test.py`:

- exact distances are a fixed point of the operator, for a model with one output and for a Q-model (column by column, which catches transposed generators); value iteration from zero converges to exact distances layer by layer (`values == distances.clamp(max=k)` after `k` iterations);
- the pins: the central state gets 0 and its neighbors get 1 with a model predicting 100 everywhere; negative estimates are clamped; the nearest child wins (hand-computed example); targets never carry gradients back into the target model;
- `BellmanTargets` holds a frozen copy (training the original model does not change targets until `update_target`); works with a `Predictor`, a module or any callable; batches input that does not fit in `graph.batch_size`;
- `BellmanTrainer` mixes anchors in the configured proportion (a target of 2 can only come from an anchor when the model predicts 100 everywhere), refreshes the target every epoch and keeps it for `bellman_target_update_period` epochs, trains a Q-model with dense targets, and continues from a checkpoint;
- sanity: with a learning rate of 1e-12 the scale does not move — bootstrapping by itself changes nothing;
- errors: wrong `n_outputs`, a target model with a 3-D output, `bellman_anchors_depth < 1` (anchors cannot be turned off), `bellman_target_update_period <= 0`, a checkpoint for another graph;
- slow tier (`RUN_SLOW_TESTS`): the fine-tuning and from-scratch numbers above.

`./lint.sh` (black 74 files, pylint 10.00/10, mypy 72 files), repo-wide `black --check .`, `docs/build_docs.sh` (`-W`) and doctests are green. `RUN_SLOW_TESTS=1 pytest` = **430 passed / 12 skipped / 3 xfailed** on Python 3.12 (torch 2.13) and on Python 3.9 (torch 2.8).

Idea and the anchors-in-the-Bellman-batch detail come from the `alexandervc/cayleypy-rw-modelbaselines-megaminx` notebooks.



---

Based on `base/bellman-finetune`, a mechanical merge of #201 and #193 with no changes of its own. Both should be merged first — #193 is needed for `Predictor.n_outputs`, which lets a wrapped Q-model be the Bellman target.
