### PR TITLE
Add lower bound pruning to simple beam search

### DIFF
--- a/cayleypy/__init__.py
+++ b/cayleypy/__init__.py
@@ -5,6 +5,7 @@ from .cayley_path import CayleyPath
 from .create_graph import create_graph
 from .datasets import load_dataset
 from .graphs_lib import prepare_graph, PermutationGroups, MatrixGroups
+from .lower_bound import BfsLowerBound, LowerBound
 from .models import ModelConfig, load_checkpoint, save_checkpoint
 from .predictor import Predictor
 from .puzzles import Puzzles, GapPuzzles

--- a/cayleypy/algo/beam_search.py
+++ b/cayleypy/algo/beam_search.py
@@ -14,6 +14,7 @@ from ..torch_utils import isin_via_searchsorted
 
 if TYPE_CHECKING:
     from ..cayley_graph import CayleyGraph
+    from ..lower_bound import LowerBound
     from ..symmetries import SymmetryGroup
 
 
@@ -125,6 +126,43 @@ def _dedup_by_canonical_form(graph: "CayleyGraph", states: torch.Tensor, symmetr
     return _unique_index(graph.hasher.make_hashes(graph.encode_states(canonical_states)))
 
 
+def _states_within_budget(
+    graph: "CayleyGraph", states: torch.Tensor, lower_bound: "LowerBound", budget: int
+) -> torch.Tensor:
+    """Returns mask of states from which the central state can still be reached in `budget` steps or less.
+
+    :param graph: The Cayley graph.
+    :param states: States to filter (in internal representation).
+    :param lower_bound: Admissible lower bound on distance from a state to the central state.
+    :param budget: How many steps are left, i.e. the maximal allowed distance from a state to the central state.
+    :return: Boolean mask of states to keep.
+    """
+    bounds = lower_bound.lb(graph.decode_states(states))
+    if tuple(bounds.shape) != (int(states.shape[0]),):
+        raise ValueError(
+            f"lower_bound.lb returned bounds of shape {tuple(bounds.shape)}, but shape {(int(states.shape[0]),)} "
+            "was expected."
+        )
+    return bounds <= budget
+
+
+def _filter_layer(
+    keep: torch.Tensor, states: torch.Tensor, hashes: torch.Tensor, expanded: Optional[_ExpandedLayer]
+) -> tuple[torch.Tensor, torch.Tensor, Optional[_ExpandedLayer]]:
+    """Keeps only some states of a layer, keeping their provenance matched with them.
+
+    :param keep: Indexes of states to keep, or a boolean mask of states to keep.
+    :param states: States of the layer (in internal representation).
+    :param hashes: Hashes of `states`.
+    :param expanded: Provenance of `states`, or None if it is not tracked.
+    :return: The remaining states, their hashes and their provenance.
+    """
+    states, hashes = states[keep, :], hashes[keep]
+    if expanded is not None:
+        expanded = _ExpandedLayer(states, hashes, expanded.moves[keep], expanded.source_index[keep])
+    return states, hashes, expanded
+
+
 def _score_children(graph: "CayleyGraph", predictor: Predictor, states: torch.Tensor) -> torch.Tensor:
     """Estimates scores of all children of `states`, calling the predictor once per state (not once per child).
 
@@ -175,6 +213,8 @@ class BeamSearchAlgorithm:
         use_child_scores: bool = False,
         canonical_dedup: Optional["SymmetryGroup"] = None,
         non_backtracking: bool = False,
+        lower_bound: Optional["LowerBound"] = None,
+        prune_above: Optional[int] = None,
         verbose: int = 0,
     ) -> BeamSearchResult:
         """Tries to find a path from `start_state` to destination state using Beam Search algorithm.
@@ -205,6 +245,10 @@ class BeamSearchAlgorithm:
             (see :meth:`search_simple`). Defaults to None, which means no deduplication by symmetries.
         :param non_backtracking: For "simple" mode, whether to ban moves undoing the previous move
             (see :meth:`search_simple`). In "advanced" mode, use `history_depth` instead. Defaults to False.
+        :param lower_bound: For "simple" mode, admissible lower bound on distance to the central state, used together
+            with `prune_above` (see :meth:`search_simple`). Defaults to None, which means no pruning.
+        :param prune_above: For "simple" mode, maximal length of a path we are interested in
+            (see :meth:`search_simple`). Defaults to None, which means no pruning.
         :param verbose: Verbosity level (0=quiet, 1=basic, 10=detailed, 100=profiling).
         :return: BeamSearchResult containing found path length and (optionally) the path itself.
         """
@@ -219,6 +263,8 @@ class BeamSearchAlgorithm:
                 use_child_scores=use_child_scores,
                 canonical_dedup=canonical_dedup,
                 non_backtracking=non_backtracking,
+                lower_bound=lower_bound,
+                prune_above=prune_above,
             )
         elif beam_mode == "advanced":
             if use_child_scores:
@@ -227,6 +273,8 @@ class BeamSearchAlgorithm:
                 raise ValueError("canonical_dedup is supported only in 'simple' beam mode.")
             if non_backtracking:
                 raise ValueError("non_backtracking is supported only in 'simple' beam mode, use history_depth here.")
+            if lower_bound is not None or prune_above is not None:
+                raise ValueError("lower_bound and prune_above are supported only in 'simple' beam mode.")
             return self.search_advanced(
                 start_state=start_state,
                 destination_state=destination_state,
@@ -251,6 +299,8 @@ class BeamSearchAlgorithm:
         use_child_scores: bool = False,
         canonical_dedup: Optional["SymmetryGroup"] = None,
         non_backtracking: bool = False,
+        lower_bound: Optional["LowerBound"] = None,
+        prune_above: Optional[int] = None,
     ) -> BeamSearchResult:
         """Tries to find a path from `start_state` to central state using simple Beam Search algorithm.
 
@@ -282,6 +332,15 @@ class BeamSearchAlgorithm:
             another state of the beam), it stays. This pays off when the beam is narrow enough to be truncated; for a
             beam wide enough to hold the whole layer, banning only removes states from it. Requires the generators to
             be inverse-closed. Defaults to False.
+        :param lower_bound: Admissible lower bound on distance from a state to the central state
+            (see :class:`cayleypy.LowerBound`), used to drop states that cannot be on a path of length at most
+            `prune_above`. Dropping them makes room in the beam for states that still can. Must be specified together
+            with `prune_above`. Defaults to None, which means no pruning.
+        :param prune_above: Maximal length of a path we are interested in, usually a path length from a previous run
+            that we want to improve on. A state reached in `k` steps is dropped when ``k + lower_bound(state)`` is
+            greater than this. Paths longer than this may still be found (pruning only guarantees that no path of
+            length at most `prune_above` is lost). Must be specified together with `lower_bound`. Defaults to None,
+            which means no pruning.
         :return: BeamSearchResult containing found path length and (optionally) the path itself.
         """
         graph = self.graph
@@ -289,6 +348,13 @@ class BeamSearchAlgorithm:
             predictor = Predictor(graph, "hamming")
         if canonical_dedup is not None:
             _check_symmetries_match_graph(graph, canonical_dedup)
+        if (lower_bound is None) != (prune_above is None):
+            raise ValueError(
+                "lower_bound and prune_above must be specified together: without a lower bound there is nothing to "
+                "compare with prune_above, and without prune_above the lower bound has no effect."
+            )
+        if prune_above is not None and prune_above < 0:
+            raise ValueError(f"prune_above must be non-negative, got {prune_above}.")
         inverse_generators = _inverse_generators(graph) if non_backtracking else None
 
         start_states = graph.encode_states(start_state)
@@ -356,9 +422,16 @@ class BeamSearchAlgorithm:
                 # start state in `i+1` steps through kept states of the previous layers, so path restoration and the
                 # reported path length remain correct.
                 keep = _dedup_by_canonical_form(graph, layer2, canonical_dedup)
-                layer2, layer2_hashes = layer2[keep, :], layer2_hashes[keep]
-                if expanded is not None:
-                    expanded = _ExpandedLayer(layer2, layer2_hashes, expanded.moves[keep], expanded.source_index[keep])
+                layer2, layer2_hashes, expanded = _filter_layer(keep, layer2, layer2_hashes, expanded)
+
+            if lower_bound is not None and prune_above is not None:
+                # Drop states from which the central state cannot be reached within the remaining budget of steps.
+                # States of this layer were reached in `i+1` steps, so `prune_above-(i+1)` steps are left.
+                keep = _states_within_budget(graph, layer2, lower_bound, prune_above - (i + 1))
+                layer2, layer2_hashes, expanded = _filter_layer(keep, layer2, layer2_hashes, expanded)
+                if layer2.shape[0] == 0:
+                    # No state can be on a path of length at most `prune_above`, so there is no such path.
+                    return BeamSearchResult(False, 0, None, debug_scores, graph.definition)
 
             layer2_moves = expanded.moves if expanded is not None else None
 

--- a/cayleypy/algo/beam_search.py
+++ b/cayleypy/algo/beam_search.py
@@ -446,10 +446,7 @@ class BeamSearchAlgorithm:
                     scores = predictor(graph.decode_states(layer2))
                 idx = torch.argsort(scores)[:beam_width]
                 best_score = float(scores[idx[0]].detach())
-                # Provenance is reordered along with the states, so it keeps describing the states next to it.
-                layer2, layer2_hashes = layer2[idx, :], layer2_hashes[idx]
-                if expanded is not None:
-                    expanded = _ExpandedLayer(layer2, layer2_hashes, expanded.moves[idx], expanded.source_index[idx])
+                layer2, layer2_hashes, expanded = _filter_layer(idx, layer2, layer2_hashes, expanded)
                 debug_scores[i] = best_score
                 if graph.verbose >= 2:
                     print(f"Iteration {i}, best score {best_score}.")

--- a/cayleypy/algo/beam_search_test.py
+++ b/cayleypy/algo/beam_search_test.py
@@ -10,6 +10,7 @@ import torch
 from ..cayley_graph import CayleyGraph
 from ..cayley_graph_def import CayleyGraphDef
 from ..graphs_lib import PermutationGroups, MatrixGroups, prepare_graph
+from ..lower_bound import BfsLowerBound
 from ..predictor import Predictor
 from ..puzzles import Puzzles
 from ..symmetries import SymmetryGroup
@@ -673,6 +674,243 @@ def test_beam_search_non_backtracking_not_supported_in_advanced_mode():
 
     with pytest.raises(ValueError, match="only in 'simple' beam mode"):
         graph.beam_search(start_state=[4, 1, 0, 2, 3], beam_mode="advanced", non_backtracking=True)
+
+
+# =============================================================================
+# Tests for lower bound pruning in "simple" beam search mode
+# =============================================================================
+
+
+def _exact_distances(graph: CayleyGraph) -> dict[tuple[int, ...], int]:
+    """Returns exact distances from all states to the central state, computed by BFS."""
+    bfs_result = graph.bfs(max_layer_size_to_store=None)
+    return {tuple(int(x) for x in s): d for d, layer in bfs_result.layers.items() for s in layer}
+
+
+def _exact_lower_bound(graph: CayleyGraph) -> BfsLowerBound:
+    """Returns lower bound that is exact for every state of the graph (full BFS)."""
+    return BfsLowerBound(graph, graph.bfs(return_all_hashes=True))
+
+
+class _WrongShapeLowerBound:
+    """Lower bound returning one value for the whole batch instead of one value per state."""
+
+    def lb(self, states: torch.Tensor) -> torch.Tensor:
+        assert states.shape[0] > 0
+        return torch.zeros((1,), dtype=torch.int64)
+
+
+def test_beam_search_lower_bound_with_exact_bound_finds_optimal_paths():
+    """Test that with an exact lower bound, the beam keeps only states on optimal paths.
+
+    A state reached in `k` steps is kept only if `k+lb(state) <= prune_above`. When the bound is exact and
+    `prune_above` is the true distance, this means the state is on some optimal path. So beam search finds an optimal
+    path from every state, even with beam width 1 (where it otherwise follows the Hamming heuristic and gets stuck).
+    """
+    graph = CayleyGraph(PermutationGroups.lrx(5), device="cpu")
+    lower_bound = _exact_lower_bound(graph)
+    solved_plain, solved_pruned = 0, 0
+
+    for state, distance in _exact_distances(graph).items():
+        if distance == 0:
+            continue
+        kwargs = {"start_state": list(state), "beam_width": 1, "max_steps": 30, "return_path": True}
+        plain = graph.beam_search(**kwargs)
+        pruned = graph.beam_search(lower_bound=lower_bound, prune_above=distance, **kwargs)
+        solved_plain += plain.path_found
+        assert pruned.path_found, f"No path found from {state}, but the optimal path was not pruned."
+        assert pruned.path_length == distance
+        _validate_beam_search_result(graph, list(state), pruned)
+        solved_pruned += 1
+
+    assert solved_plain < 15
+    assert solved_pruned == 119
+
+
+def test_beam_search_lower_bound_does_not_change_result_when_bound_is_not_binding():
+    """Test that pruning with a large `prune_above` changes nothing (nothing can be pruned)."""
+    graph = CayleyGraph(PermutationGroups.lrx(8), device="cpu")
+    lower_bound = BfsLowerBound(graph, graph.bfs(max_diameter=3, return_all_hashes=True))
+    start_state = [3, 0, 2, 4, 5, 6, 7, 1]
+    kwargs = {"start_state": start_state, "beam_width": 10, "max_steps": 50, "return_path": True}
+
+    result1 = graph.beam_search(**kwargs)
+    result2 = graph.beam_search(lower_bound=lower_bound, prune_above=1000, **kwargs)
+
+    _validate_beam_search_result(graph, start_state, result2)
+    assert result1.path == result2.path
+    assert len(result1.debug_scores) > 0
+    assert result1.debug_scores == result2.debug_scores
+
+
+def test_beam_search_lower_bound_disabled_by_default():
+    """Test that without `lower_bound` and `prune_above`, the search is exactly the old one."""
+    graph = CayleyGraph(PermutationGroups.lrx(8), device="cpu")
+    start_state = [3, 0, 2, 4, 5, 6, 7, 1]
+    kwargs = {"start_state": start_state, "beam_width": 10, "max_steps": 50, "return_path": True}
+
+    result1 = graph.beam_search(**kwargs)
+    result2 = graph.beam_search(lower_bound=None, prune_above=None, **kwargs)
+
+    assert result1.path == result2.path
+    assert len(result1.debug_scores) > 0
+    assert result1.debug_scores == result2.debug_scores
+
+
+def test_beam_search_prune_above_below_distance_fails_immediately():
+    """Test that the search stops as soon as the lower bound says the budget cannot be met."""
+    graph = CayleyGraph(PermutationGroups.lrx(6), device="cpu")
+    lower_bound = _exact_lower_bound(graph)
+    start_state = [5, 4, 3, 2, 1, 0]
+    distance = _exact_distances(graph)[tuple(start_state)]
+    assert distance == 13
+
+    result = graph.beam_search(
+        start_state=start_state, beam_width=100, max_steps=50, lower_bound=lower_bound, prune_above=distance
+    )
+
+    assert result.path_found and result.path_length == distance
+    for prune_above in range(distance):
+        pruned = graph.beam_search(
+            start_state=start_state, beam_width=100, max_steps=50, lower_bound=lower_bound, prune_above=prune_above
+        )
+        assert not pruned.path_found
+        # All states of the layer are pruned as soon as the remaining budget is less than the distance left to go.
+        assert len(pruned.debug_scores) <= prune_above
+
+
+def test_beam_search_prune_above_does_not_reject_a_found_path():
+    """Test that a path is not lost because it is longer than the budget: pruning happens after the path is found."""
+    graph = CayleyGraph(PermutationGroups.lrx(6), device="cpu")
+    lower_bound = _exact_lower_bound(graph)
+    kwargs = {"beam_width": 10, "max_steps": 50, "lower_bound": lower_bound, "prune_above": 0}
+
+    # The central state is one step away, and reaching it is noticed before anything is pruned.
+    result1 = graph.beam_search(start_state=[1, 0, 2, 3, 4, 5], **kwargs)
+    # Here it is two steps away, and everything is pruned after the first step.
+    result2 = graph.beam_search(start_state=[1, 2, 0, 3, 4, 5], **kwargs)
+
+    assert result1.path_found and result1.path_length == 1
+    assert not result2.path_found
+
+
+@pytest.mark.skipif(not RUN_SLOW_TESTS, reason="slow test")
+def test_beam_search_lower_bound_from_partial_bfs_gets_stronger_with_radius():
+    """Test that a bound from a larger ball prunes more, so more states are solved optimally."""
+    graph = CayleyGraph(PermutationGroups.lrx(6), device="cpu")
+    distances = _exact_distances(graph)
+    solved = {}
+
+    for radius in [0, 3, 9]:
+        lower_bound = BfsLowerBound(graph, graph.bfs(max_diameter=radius, return_all_hashes=True))
+        solved[radius] = 0
+        for state, distance in distances.items():
+            if distance == 0:
+                continue
+            result = graph.beam_search(
+                start_state=list(state),
+                beam_width=3,
+                max_steps=30,
+                lower_bound=lower_bound,
+                prune_above=distance,
+            )
+            # Every path found under this bound has optimal length, because longer paths are pruned.
+            assert not result.path_found or result.path_length == distance
+            solved[radius] += result.path_found
+
+    # With radius 0, the bound is "0 for the central state, 1 for everything else" - almost nothing is pruned.
+    assert solved[0] < 50
+    assert solved[3] > 100
+    assert solved[9] > 600
+
+
+def test_beam_search_lower_bound_with_child_scores_dedup_and_non_backtracking():
+    """Test that pruning keeps scores and moves of children matched with the states they belong to."""
+    graph_def = PermutationGroups.lrx(8)
+    graph = CayleyGraph(graph_def, device="cpu")
+    lower_bound = BfsLowerBound(graph, graph.bfs(max_diameter=3, return_all_hashes=True))
+    start_state = [3, 0, 2, 4, 5, 6, 7, 1]
+    kwargs = {
+        "start_state": start_state,
+        "beam_width": 10,
+        "max_steps": 50,
+        "return_path": True,
+        "lower_bound": lower_bound,
+        "prune_above": 12,
+        "canonical_dedup": SymmetryGroup.reflections(graph_def),
+        "non_backtracking": True,
+    }
+
+    result_scalar = graph.beam_search(predictor=Predictor(graph, "hamming"), **kwargs)
+    result_q = graph.beam_search(predictor=_ChildrenHammingPredictor(graph), use_child_scores=True, **kwargs)
+
+    _validate_beam_search_result(graph, start_state, result_scalar)
+    assert result_scalar.path_length <= 12
+    assert result_scalar.path == result_q.path
+    assert len(result_scalar.debug_scores) > 0
+    assert result_scalar.debug_scores == result_q.debug_scores
+
+
+def test_beam_search_lower_bound_with_meet_in_the_middle():
+    """Test that pruning works together with meet-in-the-middle."""
+    graph = CayleyGraph(PermutationGroups.lrx(8), device="cpu")
+    bfs_result = graph.bfs(max_diameter=3, return_all_hashes=True)
+    lower_bound = BfsLowerBound(graph, bfs_result)
+    start_state = [3, 0, 2, 4, 5, 6, 7, 1]
+
+    result = graph.beam_search(
+        start_state=start_state,
+        beam_width=10,
+        max_steps=50,
+        return_path=True,
+        bfs_result_for_mitm=bfs_result,
+        lower_bound=lower_bound,
+        prune_above=12,
+    )
+
+    _validate_beam_search_result(graph, start_state, result)
+
+
+def test_beam_search_lower_bound_requires_prune_above():
+    """Test that a lower bound without a budget to compare it with is rejected."""
+    graph = CayleyGraph(PermutationGroups.lrx(5), device="cpu")
+    lower_bound = _exact_lower_bound(graph)
+
+    with pytest.raises(ValueError, match="must be specified together"):
+        graph.beam_search(start_state=[4, 1, 0, 2, 3], lower_bound=lower_bound)
+
+
+def test_beam_search_prune_above_requires_lower_bound():
+    """Test that a budget without a lower bound to compare with it is rejected."""
+    graph = CayleyGraph(PermutationGroups.lrx(5), device="cpu")
+
+    with pytest.raises(ValueError, match="must be specified together"):
+        graph.beam_search(start_state=[4, 1, 0, 2, 3], prune_above=10)
+
+
+def test_beam_search_prune_above_must_be_non_negative():
+    graph = CayleyGraph(PermutationGroups.lrx(5), device="cpu")
+    lower_bound = _exact_lower_bound(graph)
+
+    with pytest.raises(ValueError, match="non-negative"):
+        graph.beam_search(start_state=[4, 1, 0, 2, 3], lower_bound=lower_bound, prune_above=-1)
+
+
+def test_beam_search_lower_bound_rejects_wrong_shape():
+    """Test that a lower bound returning one value for the whole batch is rejected."""
+    graph = CayleyGraph(PermutationGroups.lrx(5), device="cpu")
+
+    with pytest.raises(ValueError, match="shape"):
+        graph.beam_search(start_state=[4, 1, 0, 2, 3], lower_bound=_WrongShapeLowerBound(), prune_above=10)
+
+
+def test_beam_search_lower_bound_not_supported_in_advanced_mode():
+    """Test that pruning is rejected in "advanced" mode, where it is not implemented."""
+    graph = CayleyGraph(PermutationGroups.lrx(5), device="cpu")
+    lower_bound = _exact_lower_bound(graph)
+
+    with pytest.raises(ValueError, match="only in 'simple' beam mode"):
+        graph.beam_search(start_state=[4, 1, 0, 2, 3], beam_mode="advanced", lower_bound=lower_bound, prune_above=10)
 
 
 # =============================================================================

--- a/cayleypy/lower_bound.py
+++ b/cayleypy/lower_bound.py
@@ -45,7 +45,7 @@ class BfsLowerBound:
     Example:
 
     >>> from cayleypy import BfsLowerBound, CayleyGraph, PermutationGroups
-    >>> graph = CayleyGraph(PermutationGroups.lrx(6))
+    >>> graph = CayleyGraph(PermutationGroups.lrx(6), device="cpu")
     >>> lower_bound = BfsLowerBound(graph, graph.bfs(max_diameter=2, return_all_hashes=True))
     >>> lower_bound.lb([[0, 1, 2, 3, 4, 5], [1, 0, 2, 3, 4, 5], [5, 4, 3, 2, 1, 0]]).tolist()
     [0, 1, 3]

--- a/cayleypy/lower_bound.py
+++ b/cayleypy/lower_bound.py
@@ -1,0 +1,100 @@
+"""Lower bounds on distance to the central state, used to prune beam search."""
+
+from typing import Protocol, TYPE_CHECKING, runtime_checkable
+
+import torch
+
+from .algo.bfs_result import BfsResult
+
+if TYPE_CHECKING:
+    from .cayley_graph import CayleyGraph
+
+
+@runtime_checkable
+class LowerBound(Protocol):
+    """Lower bound on distance from a state to the central state.
+
+    The bound must be **admissible**: for every state, the returned value must not exceed the true distance from that
+    state to the central state. Beam search uses it to drop states that cannot be on a path shorter than a known upper
+    bound (see ``lower_bound`` and ``prune_above`` in
+    :meth:`cayleypy.algo.BeamSearchAlgorithm.search_simple`). A bound that is not admissible can make the search miss
+    paths that it would otherwise find.
+
+    This is a protocol: any object having the ``lb`` method can be used, it does not have to inherit from this class.
+    """
+
+    def lb(self, states: torch.Tensor) -> torch.Tensor:
+        """Estimates lower bounds on distances from given states to the central state.
+
+        :param states: One state (1-D tensor) or multiple states (2-D tensor), in decoded representation.
+        :return: Tensor of shape ``[n_states]`` with a lower bound for each state.
+        """
+
+
+class BfsLowerBound:
+    """Lower bound based on exact distances in a pre-computed ball around the central state.
+
+    BFS from the central state gives exact distances for all states within some radius ``d`` of it. For a state inside
+    that ball, the exact distance is returned, which is the strongest possible bound. Every other state is at distance
+    at least ``d+1``, and that is what is returned for it. The larger the ball, the stronger the bound - and the more
+    memory it takes (one hash per state in the ball).
+
+    Generators must be inverse-closed, so that distance from the central state to a state is equal to distance from
+    that state back to the central state.
+
+    Example:
+
+    >>> from cayleypy import BfsLowerBound, CayleyGraph, PermutationGroups
+    >>> graph = CayleyGraph(PermutationGroups.lrx(6))
+    >>> lower_bound = BfsLowerBound(graph, graph.bfs(max_diameter=2, return_all_hashes=True))
+    >>> lower_bound.lb([[0, 1, 2, 3, 4, 5], [1, 0, 2, 3, 4, 5], [5, 4, 3, 2, 1, 0]]).tolist()
+    [0, 1, 3]
+    """
+
+    def __init__(self, graph: "CayleyGraph", bfs_result: BfsResult):
+        """Initializes BfsLowerBound.
+
+        :param graph: The Cayley graph. Distances are to the central state of this graph.
+        :param bfs_result: Result of BFS from the central state of `graph`, computed with ``return_all_hashes=True``.
+            It must be computed by the same `CayleyGraph` object, because states are looked up by hash, and hashing
+            depends on a random seed stored in the graph.
+        """
+        if not graph.definition.generators_inverse_closed:
+            raise ValueError(
+                "BfsLowerBound requires inverse-closed generators (for every generator, its inverse must also be a "
+                "generator), otherwise distances computed by BFS from the central state are distances in the wrong "
+                "direction."
+            )
+        if bfs_result.graph != graph.definition:
+            raise ValueError("BFS was run on a different graph.")
+        layers_hashes = bfs_result.layers_hashes
+        if len(layers_hashes) != len(bfs_result.layer_sizes):
+            raise ValueError("Hashes for some layers are missing. Run bfs with return_all_hashes=True.")
+        if len(layers_hashes[0]) != 1 or int(layers_hashes[0][0]) != int(graph.central_state_hash[0]):
+            raise ValueError(
+                "BFS must be started from the central state (which is the default), and must be run by the same "
+                "CayleyGraph object, because states are looked up by hash."
+            )
+        device = graph.device
+        hashes = torch.cat([h.reshape(-1).to(device) for h in layers_hashes])
+        distances = torch.cat(
+            [torch.full((len(h),), i, dtype=torch.int64, device=device) for i, h in enumerate(layers_hashes)]
+        )
+        order = torch.argsort(hashes)
+        self.graph = graph
+        self.radius = len(layers_hashes) - 1
+        """Radius of the ball for which exact distances are known."""
+        self._hashes = hashes[order]
+        self._distances = distances[order]
+
+    def lb(self, states: torch.Tensor) -> torch.Tensor:
+        """Returns exact distances for states within the ball, and ``radius+1`` for all other states.
+
+        :param states: One state (1-D tensor) or multiple states (2-D tensor), in decoded representation.
+        :return: Tensor of shape ``[n_states]`` with a lower bound for each state.
+        """
+        hashes = self.graph.hasher.make_hashes(self.graph.encode_states(states))
+        idx = torch.searchsorted(self._hashes, hashes).clamp(max=self._hashes.shape[0] - 1)
+        found = self._hashes[idx] == hashes
+        outside = torch.full_like(hashes, self.radius + 1)
+        return torch.where(found, self._distances[idx], outside)

--- a/cayleypy/lower_bound_test.py
+++ b/cayleypy/lower_bound_test.py
@@ -1,0 +1,167 @@
+import os
+
+import pytest
+import torch
+
+from .algo.bfs_result import BfsResult
+from .cayley_graph import CayleyGraph
+from .graphs_lib import PermutationGroups
+from .lower_bound import BfsLowerBound, LowerBound
+from .puzzles import Puzzles
+
+RUN_SLOW_TESTS = os.getenv("RUN_SLOW_TESTS") == "1"
+
+
+def exact_distances(bfs_result: BfsResult) -> tuple[torch.Tensor, torch.Tensor]:
+    """Returns all states of a completed BFS and their exact distances from the central state."""
+    assert bfs_result.bfs_completed
+    distances = [torch.full((n,), i, dtype=torch.int64) for i, n in enumerate(bfs_result.layer_sizes)]
+    return bfs_result.all_states, torch.cat(distances)
+
+
+def test_lower_bound_is_exact_when_bfs_is_complete():
+    graph = CayleyGraph(PermutationGroups.lrx(6), device="cpu")
+    bfs_result = graph.bfs(max_layer_size_to_store=None, return_all_hashes=True)
+    states, distances = exact_distances(bfs_result)
+
+    lower_bound = BfsLowerBound(graph, bfs_result)
+
+    assert lower_bound.radius == bfs_result.diameter()
+    assert torch.equal(lower_bound.lb(states), distances)
+
+
+def test_lower_bound_is_exact_inside_ball_and_admissible_outside():
+    graph = CayleyGraph(PermutationGroups.lrx(6), device="cpu")
+    states, distances = exact_distances(graph.bfs(max_layer_size_to_store=None, return_all_hashes=True))
+    radius = 4
+
+    lower_bound = BfsLowerBound(graph, graph.bfs(max_diameter=radius, return_all_hashes=True))
+
+    bounds = lower_bound.lb(states)
+    assert lower_bound.radius == radius
+    # Admissibility: the bound never exceeds the true distance.
+    assert bool(torch.all(bounds <= distances))
+    inside = distances <= radius
+    assert bool(torch.all(bounds[inside] == distances[inside]))
+    # Everything outside the ball is at distance at least radius+1, and that is what is returned for it.
+    assert bool(torch.all(bounds[~inside] == radius + 1))
+    assert int((~inside).sum()) > 0
+
+
+def test_lower_bound_for_single_state():
+    graph = CayleyGraph(PermutationGroups.lrx(6), device="cpu")
+    lower_bound = BfsLowerBound(graph, graph.bfs(max_diameter=2, return_all_hashes=True))
+
+    assert lower_bound.lb(graph.central_state).tolist() == [0]
+    assert lower_bound.lb([1, 0, 2, 3, 4, 5]).tolist() == [1]
+    assert lower_bound.lb([5, 4, 3, 2, 1, 0]).tolist() == [3]
+
+
+def test_lower_bound_for_puzzle_with_colors():
+    """Test on a graph where states are colors of stickers, not permutations."""
+    graph = CayleyGraph(Puzzles.rubik_cube(2, metric="QTM"), device="cpu")
+    radius = 3
+    lower_bound = BfsLowerBound(graph, graph.bfs(max_diameter=radius, return_all_hashes=True))
+
+    assert lower_bound.lb(graph.central_state).tolist() == [0]
+    # f0, r0, d0 - quarter turns of three different faces, which do not undo each other.
+    path = [graph.definition.generator_names.index(name) for name in ["f0", "r0", "d0"]]
+    for n_moves in range(1, radius + 1):
+        state = graph.apply_path(graph.central_state, path[:n_moves])
+        assert lower_bound.lb(state).tolist() == [n_moves]
+    far_state = graph.apply_path(graph.central_state, path * 3)
+    assert lower_bound.lb(far_state).tolist() == [radius + 1]
+
+
+def test_lower_bound_batch_matches_state_by_state():
+    graph = CayleyGraph(PermutationGroups.lrx(8), device="cpu")
+    lower_bound = BfsLowerBound(graph, graph.bfs(max_diameter=3, return_all_hashes=True))
+    states = graph.random_walks(width=20, length=6)[0]
+
+    bounds = lower_bound.lb(states)
+
+    assert bounds.shape == (states.shape[0],)
+    for i in range(states.shape[0]):
+        assert lower_bound.lb(states[i]).tolist() == [int(bounds[i])]
+
+
+def test_bfs_lower_bound_implements_lower_bound_protocol():
+    graph = CayleyGraph(PermutationGroups.lrx(5), device="cpu")
+    lower_bound = BfsLowerBound(graph, graph.bfs(max_diameter=1, return_all_hashes=True))
+
+    assert isinstance(lower_bound, LowerBound)
+    # Any object with the `lb` method can be used as a lower bound.
+    assert isinstance(_ZeroLowerBound(), LowerBound)
+    assert not isinstance(graph, LowerBound)
+
+
+class _ZeroLowerBound:
+    """Trivial (and useless, but admissible) lower bound."""
+
+    def lb(self, states: torch.Tensor) -> torch.Tensor:
+        return torch.zeros((states.shape[0],), dtype=torch.int64)
+
+
+def test_lower_bound_requires_hashes():
+    graph = CayleyGraph(PermutationGroups.lrx(5), device="cpu")
+
+    with pytest.raises(ValueError, match="return_all_hashes"):
+        BfsLowerBound(graph, graph.bfs(max_diameter=2))
+
+
+def test_lower_bound_requires_inverse_closed_generators():
+    graph_def = PermutationGroups.lx(5)
+    assert not graph_def.generators_inverse_closed
+    graph = CayleyGraph(graph_def, device="cpu")
+
+    with pytest.raises(ValueError, match="inverse-closed"):
+        BfsLowerBound(graph, graph.bfs(max_diameter=2, return_all_hashes=True))
+
+
+def test_lower_bound_rejects_bfs_for_other_graph():
+    graph1 = CayleyGraph(PermutationGroups.lrx(5), device="cpu")
+    graph2 = CayleyGraph(PermutationGroups.lrx(5, k=2), device="cpu")
+
+    with pytest.raises(ValueError, match="different graph"):
+        BfsLowerBound(graph1, graph2.bfs(max_diameter=2, return_all_hashes=True))
+
+
+def test_lower_bound_rejects_bfs_from_other_state():
+    graph = CayleyGraph(PermutationGroups.lrx(5), device="cpu")
+    bfs_result = graph.bfs(start_states=[[1, 0, 2, 3, 4]], max_diameter=2, return_all_hashes=True)
+
+    with pytest.raises(ValueError, match="started from the central state"):
+        BfsLowerBound(graph, bfs_result)
+
+
+def test_lower_bound_rejects_bfs_from_other_graph_object():
+    """Test that BFS run by another graph object is rejected, because that object hashes states differently."""
+    # State of this graph does not fit in one int64, so hashes depend on the random seed of the graph object.
+    graph_def = PermutationGroups.lrx(20)
+    graph1 = CayleyGraph(graph_def, device="cpu")
+    graph2 = CayleyGraph(graph_def, device="cpu")
+    assert graph1.hasher.seed != graph2.hasher.seed
+
+    with pytest.raises(ValueError, match="same CayleyGraph object"):
+        BfsLowerBound(graph1, graph2.bfs(max_diameter=2, return_all_hashes=True))
+
+
+@pytest.mark.skipif(not RUN_SLOW_TESTS, reason="slow test")
+def test_lower_bound_on_cube222_is_admissible():
+    """Test admissibility on the 2x2x2 cube, comparing a bound from a small ball with exact distances."""
+    graph = CayleyGraph(Puzzles.rubik_cube(2, metric="QTM"), device="cpu")
+    # Exact distances for all states reachable in 8 moves (there are almost 4 million of them).
+    exact = BfsLowerBound(graph, graph.bfs(max_diameter=8, return_all_hashes=True, max_layer_size_to_store=1))
+    radius = 5
+    lower_bound = BfsLowerBound(graph, graph.bfs(max_diameter=radius, return_all_hashes=True))
+    # Random walks of length 8 stay inside the ball for which distances are known exactly.
+    states = graph.random_walks(width=1000, length=9)[0]
+
+    bounds = lower_bound.lb(states)
+    distances = exact.lb(states)
+
+    assert bool(torch.all(bounds <= distances))
+    inside = distances <= radius
+    assert bool(torch.all(bounds[inside] == distances[inside]))
+    assert bool(torch.all(bounds[~inside] == radius + 1))
+    assert int((~inside).sum()) > 0

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -39,6 +39,8 @@ Beam search and ML
     :toctree: generated/
 
     cayleypy.Predictor
+    cayleypy.LowerBound
+    cayleypy.BfsLowerBound
     cayleypy.SymmetryGroup
     cayleypy.SymmetrizedPredictor
     cayleypy.algo.BeamSearchAlgorithm


### PR DESCRIPTION
Adds admissible lower bounds and pruning by them to `search_simple`.

## What is added

* `LowerBound` (`cayleypy/lower_bound.py`) — protocol with a single method `lb(states) -> Tensor[n_states]`. The bound must be **admissible**: it must never exceed the true distance from a state to the central state. Any object with such a method can be used (it does not have to inherit from this class).
* `BfsLowerBound` — implementation on top of `BfsResult`: BFS from the central state gives exact distances inside a ball of radius `d`, and everything outside is at distance at least `d+1`. States are looked up by hash (`searchsorted` over one sorted table), so the memory cost is one `int64` per state in the ball.
* Options `lower_bound` and `prune_above` of `search_simple` (and of `search()`, which dispatches to it). A state reached in `k` steps is dropped when `k + lb(state) > prune_above`. `prune_above` is the maximal length of a path we are interested in, usually a length from a previous run that we want to improve on.

Where pruning happens in the step: after the check whether the central state is reached (so a found path is never thrown away), after deduplication by symmetries (so `lb` is called for fewer states), and before scoring and top-k — that is the point, dropping hopeless states makes room in the beam for the rest. When the whole layer is pruned, the search stops immediately: no path of length at most `prune_above` exists.

Defaults are `None` for both, which is exactly the old behavior with no overhead. The two options must be given together (a bound without a budget has no effect, a budget without a bound has nothing to compare with), and both are rejected in "advanced" mode.

## Effect

With an exact bound (full BFS) and `prune_above` equal to the true distance, every state kept by the beam is on an optimal path, so beam search finds an optimal path even with `beam_width=1`. On `lrx(5)`, all 119 non-central states are solved optimally this way, against 10 solved by the plain search with the same beam width.

With a bound from a partial BFS the effect grows with the radius of the ball. `lrx(6)`, `beam_width=3`, `prune_above` = true distance, 719 start states, number of states solved (every found path here is optimal, longer ones are pruned): radius 0 — 22, radius 3 — 130, radius 6 — 440, radius 9 — 703.

## Notes

* Only `search_simple`, as with `use_child_scores` (#2), `canonical_dedup` (#13) and `non_backtracking` (#14). In "advanced" mode both options raise a clear error.
* `BfsLowerBound` requires inverse-closed generators: BFS from the central state measures distances in the other direction, and they are equal only then. It also requires the `BfsResult` to be computed by the same `CayleyGraph` object (hashes depend on a random seed stored in the graph); this is checked by comparing the hash of the central state.
* `bfs_bitmask` was considered as a second source of bounds and does not fit: it returns only the growth function (`list[int]`), with no way to map a state to its distance.
* Pruning guarantees that no path of length at most `prune_above` is lost, but a longer path can still be returned (the check whether the central state is reached comes first, and meet-in-the-middle can close a path through the pre-computed neighborhood). This is documented in the docstring.
* One refactoring: filtering a layer together with its provenance (`moves`, `source_index`) is now `_filter_layer`, shared by deduplication and pruning. Without it, moves and scores of children would get assigned to wrong states.

## Tests

25 new tests. `cayleypy/lower_bound_test.py`: the bound is exact when BFS is complete and inside the ball when it is not; admissibility on every state of `lrx(6)` and (slow) on the 2x2x2 cube against exact distances; a puzzle whose states are colors, not permutations; single state and batch; the protocol accepts any object with `lb`; errors — BFS without `return_all_hashes`, BFS on another graph, BFS from another state, BFS by another graph object (different hashing), generators that are not inverse-closed.

`cayleypy/algo/beam_search_test.py`: optimal paths with an exact bound and `beam_width=1`; a bound that cannot prune anything changes neither the path nor `debug_scores`; the defaults are exactly the old search; every budget below the true distance fails, and fails as soon as the bound says so; a path that is already found is not rejected for being longer than the budget; (slow) more states solved with a larger ball; combination with child scoring, deduplication by symmetries and non-backtracking (parity of a Q-model and its scalar equivalent — this catches provenance getting out of sync with states); combination with meet-in-the-middle; errors — one option without the other, negative `prune_above`, `lb` returning the wrong shape, "advanced" mode.

`./lint.sh` and `black --check .` are green, `docs/build_docs.sh` (`-W`) is green, `RUN_SLOW_TESTS=1 pytest` is **413 passed / 12 skipped / 3 xfailed** both on Python 3.12 (torch 2.13) and on Python 3.9 (torch 2.8).

Base is #14 rather than #2: this PR touches `beam_search.py`, and PRs touching that file are stacked strictly sequentially to avoid conflicts between them.


---

Based on #203, which is the base branch of this PR, so this diff is only its own change. #203 should be merged first.
