### PR TITLE
Add explicit optional beam search backend hook

### DIFF
--- a/cayleypy/__init__.py
+++ b/cayleypy/__init__.py
@@ -1,5 +1,13 @@
 from .algo import bfs_numpy, bfs_bitmask, find_path, BfsResult
 from .cayley_graph import CayleyGraph
+from .beam_search_backends import (
+    BeamSearchBackend,
+    get_beam_search_backend,
+    get_default_beam_search_backend,
+    register_beam_search_backend,
+    set_default_beam_search_backend,
+    unregister_beam_search_backend,
+)
 from .cayley_graph_def import CayleyGraphDef, MatrixGenerator
 from .cayley_path import CayleyPath
 from .create_graph import create_graph

--- a/cayleypy/beam_search_backends.py
+++ b/cayleypy/beam_search_backends.py
@@ -1,0 +1,79 @@
+"""Explicit, optional whole-search backends for :meth:`CayleyGraph.beam_search`.
+
+Importing this module does not discover or import third-party plugins. Backends
+own their capability checks, fallback policy and result validation.
+"""
+
+from threading import RLock
+from typing import TYPE_CHECKING, Any, Dict, Optional, Protocol
+
+from .algo.beam_search import BeamSearchAlgorithm
+
+if TYPE_CHECKING:
+    from .cayley_graph import CayleyGraph
+    from .algo.beam_search_result import BeamSearchResult
+
+
+class BeamSearchBackend(Protocol):
+    """Callable accepting a graph and the caller's search keyword arguments."""
+
+    def __call__(self, graph: "CayleyGraph", **kwargs: Any) -> "BeamSearchResult": ...
+
+
+def _torch_backend(graph, **kwargs):
+    return BeamSearchAlgorithm(graph).search(**kwargs)
+
+
+_LOCK = RLock()
+_BACKENDS: Dict[str, BeamSearchBackend] = {"torch": _torch_backend}
+_DEFAULT = "torch"
+
+
+def register_beam_search_backend(name: str, backend: BeamSearchBackend) -> None:
+    """Register an explicit callable. Existing names, including torch, are reserved."""
+    if not isinstance(name, str) or not name or name.strip() != name:
+        raise ValueError("backend name must be a nonempty string without surrounding whitespace")
+    if not callable(backend):
+        raise TypeError("backend must be callable")
+    with _LOCK:
+        if name in _BACKENDS:
+            raise ValueError(f"beam search backend {name!r} is already registered")
+        _BACKENDS[name] = backend
+
+
+def unregister_beam_search_backend(name: str) -> None:
+    """Remove a backend after restoring the default. The builtin torch cannot be removed."""
+    with _LOCK:
+        if name in ("torch", _DEFAULT):
+            raise ValueError("cannot unregister the builtin torch or the current default backend")
+        if name not in _BACKENDS:
+            raise ValueError(f"unknown beam search backend {name!r}")
+        del _BACKENDS[name]
+
+
+def get_default_beam_search_backend() -> str:
+    """Return the process-wide default name (initially torch)."""
+    with _LOCK:
+        return _DEFAULT
+
+
+def get_beam_search_backend(name: Optional[str] = None) -> BeamSearchBackend:
+    """Resolve a registered name, or the current default when name is None."""
+    with _LOCK:
+        selected = _DEFAULT if name is None else name
+        if not isinstance(selected, str):
+            raise TypeError("backend must be a registered name, callable, or None")
+        if selected not in _BACKENDS:
+            raise ValueError(f"unknown beam search backend {selected!r}; register it explicitly before use")
+        return _BACKENDS[selected]
+
+
+def set_default_beam_search_backend(name: str) -> str:
+    """Set the process default and return its previous name. Configure before starting threads."""
+    global _DEFAULT  # pylint: disable=global-statement
+    with _LOCK:
+        get_beam_search_backend(name)
+        if name is None:
+            raise TypeError("default backend must be a registered name")
+        previous, _DEFAULT = _DEFAULT, name
+        return previous

--- a/cayleypy/cayley_graph.py
+++ b/cayleypy/cayley_graph.py
@@ -5,7 +5,7 @@ from typing import Optional, Sequence, Union
 
 import torch
 
-from .algo.beam_search import BeamSearchAlgorithm
+from .beam_search_backends import get_beam_search_backend
 from .algo.bfs_algo import BfsAlgorithm
 from .algo.bfs_distributed import BfsDistributed
 from .algo.random_walks import RandomWalksGenerator
@@ -227,12 +227,20 @@ class CayleyGraph:
         """
         return RandomWalksGenerator(self).generate(**kwargs)
 
-    def beam_search(self, **kwargs):
+    def beam_search(self, *, backend=None, **kwargs):
         """Tries to find a path from `start_state` to central state using Beam Search algorithm.
 
         See :class:`cayleypy.algo.BeamSearchAlgorithm` for more details.
+
+        ``backend`` may be a registered name, a callable ``(graph, **kwargs)``,
+        or None to use the process default (initially ``"torch"``). The builtin
+        ``"torch"`` always runs the original algorithm. Optional backends own
+        their compatibility checks and fallback policy; errors are not hidden.
         """
-        return BeamSearchAlgorithm(self).search(**kwargs)
+        # Resolve under the registry lock, then call outside it. A backend owns
+        # its fallback policy; exceptions and results pass through unchanged.
+        search = backend if callable(backend) else get_beam_search_backend(backend)
+        return search(self, **kwargs)
 
     def restore_path(self, hashes: list[torch.Tensor], to_state: AnyStateType) -> list[int]:
         """Restores path from layers hashes.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -41,6 +41,12 @@ Beam search and ML
     cayleypy.Predictor
     cayleypy.algo.BeamSearchAlgorithm
     cayleypy.algo.BeamSearchResult
+    cayleypy.BeamSearchBackend
+    cayleypy.register_beam_search_backend
+    cayleypy.unregister_beam_search_backend
+    cayleypy.get_beam_search_backend
+    cayleypy.get_default_beam_search_backend
+    cayleypy.set_default_beam_search_backend
     cayleypy.algo.RandomWalksGenerator
     cayleypy.models.ModelConfig
     cayleypy.models.GroupTokenizer

--- a/docs/beam_search_backends.md
+++ b/docs/beam_search_backends.md
@@ -1,0 +1,54 @@
+# Optional beam search backends
+
+Existing `graph.beam_search(...)` calls use the builtin PyTorch algorithm until
+an application explicitly selects another backend. Installing a package never
+activates it: CayleyPy does not discover plugins, download sources, compile CUDA
+or load a native library at import time.
+
+An external backend receives the original graph and search keyword arguments:
+
+```python
+result = graph.beam_search(backend=my_backend, start_state=start, predictor=predictor)
+```
+
+`my_backend(graph, **kwargs)` should return a `BeamSearchResult` (or subclass)
+with paths in the original graph's generator order. It owns capability checks,
+execution, path validation and any fallback policy. CayleyPy forwards arguments,
+results and errors unchanged. It does not promise identical search frontiers,
+path lengths, scoring or performance across backends.
+
+Packages can provide an explicit enable/disable function using the registry:
+
+```python
+from cayleypy import (
+    register_beam_search_backend, set_default_beam_search_backend,
+    unregister_beam_search_backend,
+)
+
+register_beam_search_backend("my_backend", my_backend)
+previous = set_default_beam_search_backend("my_backend")
+try:
+    result = graph.beam_search(start_state=start, predictor=predictor)
+finally:
+    set_default_beam_search_backend(previous)
+    unregister_beam_search_backend("my_backend")
+```
+
+Configure the process default before launching application threads. Registry
+updates are locked; running backend calls execute outside the lock. Calls
+resolve the default when invoked, including methods saved before a default
+change. Prefer a per-call callable when independent consumers need separate
+configuration. Duplicate names are rejected. Restore the default before
+unregistering it; the builtin `torch` cannot be replaced or removed.
+
+`graph.beam_search(backend="torch", ...)` always bypasses external backends.
+It accepts the original Torch predictor and search options, not plugin-specific
+objects/options. An external backend implementing fallback can resolve the
+builtin with `get_beam_search_backend("torch")` and call it directly without
+recursing through the process default. No exception triggers automatic fallback
+inside CayleyPy.
+
+The optional [MultiGPUBeamSearch adapter](https://github.com/TryDotAtwo/MultiGPUBeamSearch/tree/main/integrations/cayleypy_native)
+uses this hook for CUDA/NCCL beam search, with its own installation requirements,
+supported graph/model contracts and explicit fallback policy. CayleyPy does not
+depend on that package or its CUDA toolchain.

--- a/docs/beam_search_backends.rst
+++ b/docs/beam_search_backends.rst
@@ -1,17 +1,18 @@
-# Optional beam search backends
+Optional beam search backends
+=============================
 
-Existing `graph.beam_search(...)` calls use the builtin PyTorch algorithm until
+Existing ``graph.beam_search(...)`` calls use the builtin PyTorch algorithm until
 an application explicitly selects another backend. Installing a package never
 activates it: CayleyPy does not discover plugins, download sources, compile CUDA
 or load a native library at import time.
 
 An external backend receives the original graph and search keyword arguments:
 
-```python
-result = graph.beam_search(backend=my_backend, start_state=start, predictor=predictor)
-```
+.. code-block:: python
 
-`my_backend(graph, **kwargs)` should return a `BeamSearchResult` (or subclass)
+   result = graph.beam_search(backend=my_backend, start_state=start, predictor=predictor)
+
+``my_backend(graph, **kwargs)`` should return a ``BeamSearchResult`` (or subclass)
 with paths in the original graph's generator order. It owns capability checks,
 execution, path validation and any fallback policy. CayleyPy forwards arguments,
 results and errors unchanged. It does not promise identical search frontiers,
@@ -19,36 +20,37 @@ path lengths, scoring or performance across backends.
 
 Packages can provide an explicit enable/disable function using the registry:
 
-```python
-from cayleypy import (
-    register_beam_search_backend, set_default_beam_search_backend,
-    unregister_beam_search_backend,
-)
+.. code-block:: python
 
-register_beam_search_backend("my_backend", my_backend)
-previous = set_default_beam_search_backend("my_backend")
-try:
-    result = graph.beam_search(start_state=start, predictor=predictor)
-finally:
-    set_default_beam_search_backend(previous)
-    unregister_beam_search_backend("my_backend")
-```
+   from cayleypy import (
+       register_beam_search_backend, set_default_beam_search_backend,
+       unregister_beam_search_backend,
+   )
+
+   register_beam_search_backend("my_backend", my_backend)
+   previous = set_default_beam_search_backend("my_backend")
+   try:
+       result = graph.beam_search(start_state=start, predictor=predictor)
+   finally:
+       set_default_beam_search_backend(previous)
+       unregister_beam_search_backend("my_backend")
 
 Configure the process default before launching application threads. Registry
 updates are locked; running backend calls execute outside the lock. Calls
 resolve the default when invoked, including methods saved before a default
 change. Prefer a per-call callable when independent consumers need separate
 configuration. Duplicate names are rejected. Restore the default before
-unregistering it; the builtin `torch` cannot be replaced or removed.
+unregistering it; the builtin ``torch`` cannot be replaced or removed.
 
-`graph.beam_search(backend="torch", ...)` always bypasses external backends.
+``graph.beam_search(backend="torch", ...)`` always bypasses external backends.
 It accepts the original Torch predictor and search options, not plugin-specific
 objects/options. An external backend implementing fallback can resolve the
-builtin with `get_beam_search_backend("torch")` and call it directly without
+builtin with ``get_beam_search_backend("torch")`` and call it directly without
 recursing through the process default. No exception triggers automatic fallback
 inside CayleyPy.
 
-The optional [MultiGPUBeamSearch adapter](https://github.com/TryDotAtwo/MultiGPUBeamSearch/tree/main/integrations/cayleypy_native)
+The optional `MultiGPUBeamSearch adapter
+<https://github.com/TryDotAtwo/MultiGPUBeamSearch/tree/main/integrations/cayleypy_native>`_
 uses this hook for CUDA/NCCL beam search, with its own installation requirements,
 supported graph/model contracts and explicit fallback policy. CayleyPy does not
 depend on that package or its CUDA toolchain.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,3 +11,4 @@ This site contains auto-generated documentation (API reference) for the library.
    :maxdepth: 1
 
    api
+   beam_search_backends

--- a/tests/test_beam_search_backends.py
+++ b/tests/test_beam_search_backends.py
@@ -1,0 +1,124 @@
+"""Backend dispatch without native dependencies or GPU initialization."""
+
+import pytest
+
+from cayleypy import (
+    CayleyGraph,
+    PermutationGroups,
+    get_beam_search_backend,
+    get_default_beam_search_backend,
+    register_beam_search_backend,
+    set_default_beam_search_backend,
+    unregister_beam_search_backend,
+)
+
+
+@pytest.fixture
+def graph():
+    return CayleyGraph(PermutationGroups.lrx(5), device="cpu", random_seed=42)
+
+
+@pytest.fixture
+def registered():
+    previous = get_default_beam_search_backend()
+    names = []
+
+    def register(name, callback):
+        register_beam_search_backend(name, callback)
+        names.append(name)
+
+    yield register
+    set_default_beam_search_backend(previous)
+    for name in reversed(names):
+        unregister_beam_search_backend(name)
+
+
+def test_default_and_explicit_torch_keep_original_search(graph):
+    assert get_default_beam_search_backend() == "torch"
+    for options in ({}, {"backend": "torch"}):
+        result = graph.beam_search(start_state=[1, 0, 2, 3, 4], return_path=True, **options)
+        assert result.path == [2]
+        assert graph.apply_path([1, 0, 2, 3, 4], result.path).reshape(-1).tolist() == [0, 1, 2, 3, 4]
+
+
+def test_callable_receives_identical_objects(graph):
+    sentinel, state, predictor = object(), object(), object()
+    calls = []
+
+    def custom(received_graph, **kwargs):
+        calls.append((received_graph, kwargs))
+        return sentinel
+
+    assert graph.beam_search(backend=custom, start_state=state, predictor=predictor) is sentinel
+    assert calls == [(graph, {"start_state": state, "predictor": predictor})]
+    assert get_default_beam_search_backend() == "torch"
+
+
+def test_registered_default_explicit_override_and_restore(graph, registered):
+    sentinel = object()
+
+    def custom(_graph, **_kwargs):
+        return sentinel
+
+    registered("test_external", custom)
+    assert get_beam_search_backend("test_external") is custom
+    assert graph.beam_search(backend="test_external") is sentinel
+    assert set_default_beam_search_backend("test_external") == "torch"
+    assert get_default_beam_search_backend() == "test_external"
+    assert get_beam_search_backend() is custom
+    assert graph.beam_search() is sentinel
+    assert graph.beam_search(backend="torch", start_state=[1, 0, 2, 3, 4], return_path=True).path == [2]
+    assert set_default_beam_search_backend("torch") == "test_external"
+
+
+def test_backend_can_fallback_without_recursive_dispatch(graph, registered):
+    def custom(received_graph, **kwargs):
+        return get_beam_search_backend("torch")(received_graph, **kwargs)
+
+    registered("test_fallback", custom)
+    set_default_beam_search_backend("test_fallback")
+    assert graph.beam_search(start_state=[1, 0, 2, 3, 4], return_path=True).path == [2]
+
+
+def test_backend_error_is_not_swallowed(graph):
+    error = RuntimeError("worker failed")
+
+    def failing(_graph, **_kwargs):
+        raise error
+
+    with pytest.raises(RuntimeError) as caught:
+        graph.beam_search(backend=failing)
+    assert caught.value is error
+
+
+def test_registry_rejects_collisions_and_protects_default(registered):
+    registered("test_owned", lambda _graph, **_kwargs: None)
+    for name in ("torch", "test_owned"):
+        with pytest.raises(ValueError, match="already registered"):
+            register_beam_search_backend(name, lambda _graph: None)
+    set_default_beam_search_backend("test_owned")
+    for name in ("torch", "test_owned"):
+        with pytest.raises(ValueError, match="cannot unregister"):
+            unregister_beam_search_backend(name)
+
+
+@pytest.mark.parametrize("selector", ["missing_backend", 17, object()])
+def test_invalid_selection_has_no_silent_fallback(graph, selector):
+    with pytest.raises((ValueError, TypeError)):
+        graph.beam_search(backend=selector)
+
+
+@pytest.mark.parametrize("name", ["", " x", "x ", None, 17])
+def test_invalid_registration_name(name):
+    with pytest.raises(ValueError):
+        register_beam_search_backend(name, lambda _graph: None)
+
+
+def test_invalid_callback_and_default_do_not_mutate_registry():
+    with pytest.raises(TypeError):
+        register_beam_search_backend("test_bad", None)
+    with pytest.raises(ValueError):
+        set_default_beam_search_backend("missing_backend")
+    with pytest.raises(TypeError):
+        set_default_beam_search_backend(None)
+    assert get_default_beam_search_backend() == "torch"


### PR DESCRIPTION
External search engines currently have to replace `CayleyGraph.beam_search` to preserve the public graph API. This adds a small, explicit whole-search backend hook while leaving the existing Torch algorithm and its default behavior unchanged.

- Accept an explicit backend callable or registered name on `graph.beam_search`.
- Provide registration, inspection and reversible process-default selection; reserve the builtin `torch` backend.
- Forward the original graph/arguments/result/errors without implicit plugin loading, dependency installation or fallback.
- Document backend ownership, thread/default behavior and the result/path contract.

Companion PR: [MultiGPUBeamSearch #4](https://github.com/TryDotAtwo/MultiGPUBeamSearch/pull/4). Its optional adapter uses this hook without monkeypatching CayleyPy. CayleyPy does not import or depend on that package, CUDA build tools or NCCL.

Validation: [all 10 CI checks passed](https://github.com/cayleypy/cayleypy/actions/runs/33415740483), including Python 3.9-3.13 on Ubuntu, Windows/macOS, formatting, pylint/mypy and Sphinx documentation. The guide uses native RST because the existing Markdown parser fails with current Markdown dependencies; no dependency changes were needed. The companion adapter's four Linux/Windows CI jobs also passed, including actual wheel installation, the released 0.1.0 compatibility path, this public hook, and real checksummed source downloads/offline reuse.

GPU limit: a fresh two-T4 run of these public PR commits could not be started because Kaggle returned HTTP 403 for both creation and reading existing owned notebooks. The adapter's pinned native snapshot has earlier real two-T4 acceptance evidence; that is explicitly separate from validation of this new hook/source setup. No fresh GPU success or performance improvement is claimed here.

No native CUDA algorithm, default search behavior, model semantics or existing open beam-search PR is modified.
