### PR TITLE
Fix/modular inverse

### DIFF
--- a/cayleypy/cayley_graph_def.py
+++ b/cayleypy/cayley_graph_def.py
@@ -6,6 +6,7 @@ from typing import Optional, Union, Any
 import numpy as np
 import torch
 
+from .matrix_utils import inverse_integer, inverse_mod
 from .permutation_utils import inverse_permutation
 
 AnyStateType = Union[torch.Tensor, np.ndarray, list]
@@ -81,10 +82,11 @@ class MatrixGenerator:
 
     @cached_property
     def inv(self):
-        """Inverse of this matrix. Throws error if matrix is not invertible."""
-        # TODO: implement modular inverse, if needed.
-        matrix_inv = np.array(np.linalg.inv(self.matrix), dtype=np.int64)
-        assert np.array_equal(self.apply(matrix_inv), np.eye(self.n)), "Matrix is not invertible."
+        """Inverse over Z/mZ, or over Z when modulo == 0."""
+        if self.modulo:
+            matrix_inv = inverse_mod(self.matrix, self.modulo)
+        else:
+            matrix_inv = inverse_integer(self.matrix)
         return MatrixGenerator.create(matrix_inv, self.modulo)
 
     def __eq__(self, other: Any) -> bool:

--- a/cayleypy/matrix_utils.py
+++ b/cayleypy/matrix_utils.py
@@ -12,12 +12,43 @@ def _bezout(a, b):
     return g, s, t
 
 
-def inverse_integer(A):
-    A = [[int(x) for x in row] for row in A]
-    n = len(A)
+def _inverse_integer_2x2(A):
+    (a, b), (c, d) = A
+    determinant = a * d - b * c
 
-    if n == 0 or any(len(row) != n for row in A):
-        raise ValueError("A must be a nonempty square matrix")
+    if abs(determinant) != 1:
+        raise ValueError("matrix is not invertible over Z")
+
+    return [
+        [determinant * d, -determinant * b],
+        [-determinant * c, determinant * a],
+    ]
+
+
+def _inverse_integer_3x3(A):
+    (a, b, c), (d, e, f), (g, h, i) = A
+
+    x = e * i - f * h
+    y = f * g - d * i
+    z = d * h - e * g
+    determinant = a * x + b * y + c * z
+
+    if abs(determinant) != 1:
+        raise ValueError("matrix is not invertible over Z")
+
+    adjugate = [
+        [x, c * h - b * i, b * f - c * e],
+        [y, a * i - c * g, c * d - a * f],
+        [z, b * g - a * h, a * e - b * d],
+    ]
+    return [
+        [determinant * value for value in row]
+        for row in adjugate
+    ]
+
+
+def _inverse_integer_generic(A):
+    n = len(A)
 
     aug = [
         row + [int(i == j) for j in range(n)]
@@ -79,6 +110,21 @@ def inverse_integer(A):
                 ]
 
     return [row[n:] for row in aug]
+
+
+def inverse_integer(A):
+    A = [[int(x) for x in row] for row in A]
+    n = len(A)
+
+    if n == 0 or any(len(row) != n for row in A):
+        raise ValueError("A must be a nonempty square matrix")
+
+    if n == 2:
+        return _inverse_integer_2x2(A)
+    if n == 3:
+        return _inverse_integer_3x3(A)
+
+    return _inverse_integer_generic(A)
 
 
 def _clean(A, m, size=None):

--- a/cayleypy/matrix_utils.py
+++ b/cayleypy/matrix_utils.py
@@ -1,0 +1,196 @@
+"""Helper functions for matrices."""
+
+from math import gcd
+
+
+def _bezout(a, b):
+    g = gcd(a, b)
+    if b == g:
+        return g, 0, 1
+    s = pow(a // g, -1, b // g)
+    t = (g - s * a) // b
+    return g, s, t
+
+
+def inverse_integer(A):
+    A = [[int(x) for x in row] for row in A]
+    n = len(A)
+
+    if n == 0 or any(len(row) != n for row in A):
+        raise ValueError("A must be a nonempty square matrix")
+
+    aug = [
+        row + [int(i == j) for j in range(n)]
+        for i, row in enumerate(A)
+    ]
+
+    for k in range(n):
+        # Prefer an existing unit pivot.
+        pivot_row = next(
+            (i for i in range(k, n) if abs(aug[i][k]) == 1),
+            None,
+        )
+
+        if pivot_row is not None:
+            aug[k], aug[pivot_row] = aug[pivot_row], aug[k]
+        else:
+            # Unimodular row operations reduce the column gcd.
+            for i in range(k + 1, n):
+                a, b = aug[k][k], aug[i][k]
+                if b == 0:
+                    continue
+
+                g, s, t = _bezout(abs(a), abs(b))
+                if a < 0:
+                    s = -s
+                if b < 0:
+                    t = -t
+
+                row_k = aug[k]
+                row_i = aug[i]
+
+                aug[k] = [
+                    s * x + t * y
+                    for x, y in zip(row_k, row_i)
+                ]
+                aug[i] = [
+                    -(b // g) * x + (a // g) * y
+                    for x, y in zip(row_k, row_i)
+                ]
+
+                if abs(aug[k][k]) == 1:
+                    break
+
+        if abs(aug[k][k]) != 1:
+            raise ValueError("Matrix is not invertible over Z")
+
+        if aug[k][k] == -1:
+            aug[k] = [-x for x in aug[k]]
+
+        for i in range(n):
+            if i == k:
+                continue
+
+            q = aug[i][k]
+            if q:
+                aug[i] = [
+                    x - q * y
+                    for x, y in zip(aug[i], aug[k])
+                ]
+
+    return [row[n:] for row in aug]
+
+
+def _clean(A, m, size=None):
+    """Reduce entries modulo m and perform the useful shape checks."""
+    if m < 2:
+        raise ValueError("modulus m must be at least 2")
+    A = [[int(x) % m for x in row] for row in A]
+    n = len(A)
+    if n == 0 or any(len(row) != n for row in A):
+        raise ValueError("A must be a nonempty square matrix")
+    if size is not None and n != size:
+        raise ValueError(f"expected a {size}x{size} matrix, got {n}x{n}")
+    return A
+
+
+def _inverse_2x2(A, m):
+    (a, b), (c, d) = A
+    s = pow((a * d - b * c) % m, -1, m)
+    return [
+        [s * d % m, -s * b % m],
+        [-s * c % m, s * a % m],
+    ]
+
+
+def _inverse_3x3(A, m):
+    (a, b, c), (d, e, f), (g, h, i) = A
+
+    x = e * i - f * h
+    y = f * g - d * i
+    z = d * h - e * g
+    s = pow((a * x + b * y + c * z) % m, -1, m)
+
+    adjugate = [
+        [x, c * h - b * i, b * f - c * e],
+        [y, a * i - c * g, c * d - a * f],
+        [z, b * g - a * h, a * e - b * d],
+    ]
+    return [[s * x % m for x in row] for row in adjugate]
+
+
+def _inverse_generic(A, m):
+    """Factorization-free Bezout--Gauss--Jordan elimination."""
+    n = len(A)
+    M = [
+        row[:] + [int(i == j) for j in range(n)]
+        for i, row in enumerate(A)
+    ]
+
+    for k in range(n):
+        # Use an existing unit pivot when possible.
+        pivot_row = next(
+            (i for i in range(k, n) if gcd(M[i][k], m) == 1),
+            None,
+        )
+        if pivot_row is not None:
+            M[k], M[pivot_row] = M[pivot_row], M[k]
+        else:
+            # Over composite moduli, several nonunits may combine into a unit.
+            for i in range(k + 1, n):
+                if gcd(M[k][k], m) == 1:
+                    break
+                b = M[i][k]
+                if b == 0:
+                    continue
+
+                a = M[k][k]
+                g, s, t = _bezout(a, b)
+                R, S = M[k][:], M[i][:]
+                M[k] = [(s * x + t * y) % m for x, y in zip(R, S)]
+                M[i] = [
+                    (-(b // g) * x + (a // g) * y) % m
+                    for x, y in zip(R, S)
+                ]
+
+        pivot = M[k][k]
+        if gcd(pivot, m) != 1:
+            raise ValueError(f"matrix is not invertible modulo {m}")
+
+        s = pow(pivot, -1, m)
+        M[k] = [s * x % m for x in M[k]]
+
+        for i in range(n):
+            if i != k and M[i][k]:
+                s = M[i][k]
+                M[i] = [(x - s * y) % m for x, y in zip(M[i], M[k])]
+
+    return [row[n:] for row in M]
+
+
+def inverse_mod(A, m, method="auto", orientation="auto"):
+    """Invert A modulo m, selecting an appropriate implementation."""
+    A = _clean(A, m)
+    n = len(A)
+
+    if method == "auto":
+        if n == 2:
+            return _inverse_2x2(A, m)
+        if n == 3:
+            return _inverse_3x3(A, m)
+        return _inverse_generic(A, m)
+
+    if method == "2x2":
+        if n != 2:
+            raise ValueError("method='2x2' requires a 2x2 matrix")
+        return _inverse_2x2(A, m)
+    if method == "3x3":
+        if n != 3:
+            raise ValueError("method='3x3' requires a 3x3 matrix")
+        return _inverse_3x3(A, m)
+    if method == "generic":
+        return _inverse_generic(A, m)
+
+    raise ValueError(
+        "method must be 'auto', '2x2', '3x3', or 'generic'"
+    )

--- a/cayleypy/matrix_utils_test.py
+++ b/cayleypy/matrix_utils_test.py
@@ -1,0 +1,234 @@
+from itertools import product
+from math import gcd
+import random
+
+import numpy as np
+import pytest
+
+from .matrix_utils import inverse_integer, inverse_mod
+
+
+def _check_integer_inverse(A):
+    A = np.asarray(A, dtype=object)
+    B = np.asarray(inverse_integer(A), dtype=object)
+    identity = np.eye(len(A), dtype=object)
+
+    assert np.array_equal(A @ B, identity)
+    assert np.array_equal(B @ A, identity)
+
+
+def _random_unimodular_matrix(n, rng):
+    A = np.eye(n, dtype=object)
+
+    for _ in range(5 * n):
+        i, j = rng.sample(range(n), 2)
+        operation = rng.randrange(3)
+
+        if operation == 0:
+            A[[i, j]] = A[[j, i]]
+        elif operation == 1:
+            c = rng.choice([-3, -2, -1, 1, 2, 3])
+            A[i] += c * A[j]
+        else:
+            A[i] = -A[i]
+
+    return A
+
+
+def test_inverse_integer_known_matrices():
+    assert inverse_integer([[1]]) == [[1]]
+    assert inverse_integer([[-1]]) == [[-1]]
+
+    assert inverse_integer(
+        [[2, 3], [3, 5]]
+    ) == [
+        [5, -3],
+        [-3, 2],
+    ]
+
+    assert inverse_integer(
+        [[1, 2, 3], [0, 1, 4], [0, 0, 1]]
+    ) == [
+        [1, -2, 5],
+        [0, 1, -4],
+        [0, 0, 1],
+    ]
+
+
+def test_inverse_integer_without_unit_pivots():
+    A = [
+        [2, 3, 0, 0],
+        [3, 5, 0, 0],
+        [0, 0, 2, 3],
+        [0, 0, 3, 5],
+    ]
+    _check_integer_inverse(A)
+
+
+def test_inverse_integer_large_entries():
+    # This unimodular example is already inaccurate with np.linalg.inv.
+    A = [
+        [17711, 10946],
+        [10946, 6765],
+    ]
+    assert inverse_integer(A) == [
+        [-6765, 10946],
+        [10946, -17711],
+    ]
+
+
+def test_inverse_integer_2x2_exhaustive():
+    for values in product(range(-2, 3), repeat=4):
+        A = [list(values[:2]), list(values[2:])]
+        determinant = values[0] * values[3] - values[1] * values[2]
+
+        if abs(determinant) == 1:
+            _check_integer_inverse(A)
+        else:
+            with pytest.raises(ValueError):
+                inverse_integer(A)
+
+
+def test_inverse_integer_generated_unimodular_matrices():
+    rng = random.Random(12345)
+
+    for n in range(2, 8):
+        for _ in range(20):
+            _check_integer_inverse(
+                _random_unimodular_matrix(n, rng)
+            )
+
+
+def test_inverse_integer_numpy_input_and_no_mutation():
+    A = np.array([[2, 3], [3, 5]], dtype=np.int64)
+    A_before = A.copy()
+
+    assert inverse_integer(A) == [[5, -3], [-3, 2]]
+    assert np.array_equal(A, A_before)
+
+
+def test_inverse_integer_noninvertible():
+    matrices = [
+        [[0]],
+        [[2]],                         # Invertible over Q, not over Z.
+        [[1, 2], [2, 4]],              # Singular.
+        [[2, 1], [0, 1]],              # Determinant 2.
+        [[1, 0, 0], [0, -1, 0], [0, 0, 3]],
+    ]
+
+    for A in matrices:
+        with pytest.raises(ValueError):
+            inverse_integer(A)
+
+
+def test_inverse_integer_invalid_shape():
+    for A in [[], [[1, 2]], [[1], [2]], [[1, 0], [0, 1, 0]]]:
+        with pytest.raises(ValueError):
+            inverse_integer(A)
+
+
+def _check_inverse(A, m):
+    A = np.asarray(A, dtype=np.int64)
+    B = np.asarray(inverse_mod(A, m), dtype=np.int64)
+    identity = np.eye(len(A), dtype=np.int64)
+
+    assert np.array_equal(A @ B % m, identity)
+    assert np.array_equal(B @ A % m, identity)
+    assert np.all((0 <= B) & (B < m))
+
+
+def _random_invertible_matrix(n, m, rng):
+    A = np.eye(n, dtype=np.int64)
+    units = [x for x in range(1, m) if gcd(x, m) == 1]
+
+    for _ in range(5 * n):
+        i, j = rng.sample(range(n), 2)
+        operation = rng.randrange(3)
+        if operation == 0:
+            A[[i, j]] = A[[j, i]]
+        elif operation == 1:
+            c = rng.randrange(m)
+            A[i] = (A[i] + c * A[j]) % m
+        else:
+            c = rng.choice(units)
+            A[i] = c * A[i] % m
+
+    return A
+
+
+def test_inverse_mod_1x1():
+    assert inverse_mod([[1]], 2) == [[1]]
+    assert inverse_mod([[5]], 12) == [[5]]
+    assert inverse_mod([[7]], 15) == [[13]]
+
+
+def test_inverse_mod_2x2():
+    assert inverse_mod([[1, 2], [3, 4]], 5) == [[3, 1], [4, 2]]
+    assert inverse_mod([[2, 3], [3, 2]], 6) == [[2, 3], [3, 2]]
+    assert inverse_mod([[-1, 2], [3, 6]], 5) == [[2, 1], [4, 3]]
+
+
+def test_inverse_mod_2x2_exhaustive():
+    for m in range(2, 8):
+        for values in product(range(m), repeat=4):
+            A = [list(values[:2]), list(values[2:])]
+            determinant = values[0] * values[3] - values[1] * values[2]
+            if gcd(determinant, m) == 1:
+                _check_inverse(A, m)
+            else:
+                with pytest.raises(ValueError):
+                    inverse_mod(A, m)
+
+
+def test_inverse_mod_3x3():
+    A = [[2, 1, 3], [1, 1, 1], [4, 2, 1]]
+    assert inverse_mod(A, 7) == [[3, 6, 6], [5, 2, 4], [6, 0, 4]]
+
+    _check_inverse([[1, 2, 3], [0, 1, 4], [0, 0, 1]], 12)
+    _check_inverse([[2, 5, 1], [1, 3, 2], [4, 0, 3]], 11)
+
+
+def test_inverse_mod_generic_without_unit_pivots():
+    A = [
+        [2, 3, 0, 0],
+        [3, 2, 0, 0],
+        [0, 0, 2, 3],
+        [0, 0, 3, 2],
+    ]
+    assert inverse_mod(A, 6) == A
+
+
+def test_inverse_mod_generated_invertible_matrices():
+    rng = random.Random(12345)
+    for n in range(2, 8):
+        for m in [2, 4, 5, 6, 8, 9, 10, 12, 15]:
+            for _ in range(10):
+                A = _random_invertible_matrix(n, m, rng)
+                _check_inverse(A, m)
+
+
+def test_inverse_mod_numpy_input_and_no_mutation():
+    A = np.array([[1, 2], [3, 4]], dtype=np.int64)
+    A_before = A.copy()
+    assert inverse_mod(A, 5) == [[3, 1], [4, 2]]
+    assert np.array_equal(A, A_before)
+
+
+def test_inverse_mod_noninvertible():
+    matrices = [
+        ([[1, 2], [2, 4]], 5),
+        ([[1, 0, 0], [0, 2, 0], [0, 0, 1]], 6),
+        ([[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0], [0, 0, 0, 2]], 6),
+    ]
+    for A, m in matrices:
+        with pytest.raises(ValueError):
+            inverse_mod(A, m)
+
+
+def test_inverse_mod_invalid_shape():
+    for A in [[], [[1, 2]], [[1], [2]], [[1, 0], [0, 1, 0]]]:
+        with pytest.raises(ValueError):
+            inverse_mod(A, 5)
+
+    with pytest.raises(ValueError):
+        inverse_mod([[1]], 1)


### PR DESCRIPTION
Completed a TODO for modular inverses of MatrixGenerator's, thus fixing BeamSearch on matrices with return_path=True.
There is now a separate matrix_utils.py, test-covered. It contains the inversion routines. Apart from modular inversions, inversions over Z are now also safe (check invertibility and perform division-free inversion).
Inversion for 2x2 and 3x3 matrices are straightforward with Cramer's formulas.