### PR TITLE
Use Python3.14 in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.14'
           architecture: 'x64'
       - name: Install black
         run: pip install black==25.1.0
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.14'
           architecture: 'x64'
       - name: Install requirements
         run: pip install .[lint,test]
@@ -36,7 +36,7 @@ jobs:
   pytest-ubuntu:
     strategy:
       matrix:
-        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13', '3.14' ]
     name: Tests (Ubuntu)
     runs-on: ubuntu-latest
     steps:
@@ -56,7 +56,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.14'
           architecture: 'x64'
       - name: Install requirements
         run: pip install .[test]
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.12'
+          python-version: '3.14'
           architecture: 'x64'
       - name: Install requirements
         run: pip install .[test]
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: '3.14'
           architecture: 'x64'
       - name: Install requirements
         run: |

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,8 +5,6 @@ import inspect
 import os
 import sys
 
-from sphinx_markdown_parser.parser import MarkdownParser
-
 # -- Path setup --------------------------------------------------------------
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -17,8 +15,6 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
 
 def setup(app):
-    app.add_source_parser(MarkdownParser)
-    app.add_config_value("pandoc_use_parser", "markdown", True)
     app.connect("autodoc-process-signature", autodoc_process_signature)
     app.add_css_file("custom.css")
 
@@ -66,13 +62,6 @@ html_theme = "sphinx_rtd_theme"
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = []
-
-# Allow markdown includes.
-# http://www.sphinx-doc.org/en/master/markdown.html
-source_suffix = {
-    ".rst": "restructuredtext",
-    ".md": "markdown",
-}
 
 # Home page for documentation.
 master_doc = "index"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,9 +48,8 @@ dev = [
 ]
 docs = [
     # Libraries needed to build documentation.
-    "sphinx",
+    "sphinx>=9.1.0",
     "sphinx_rtd_theme",
-    "sphinx_markdown_parser",
 ]
 
 [project.urls]


### PR DESCRIPTION
* This officially supports Python 3.14.
* Also removed dependency on sphinx_markdown_parser which have not been updated for 6 years, and turns out we don't need it because we don't use markdown in our docs.