### PR TITLE
Fix non-backtracking random walks

### DIFF
--- a/cayleypy/algo/random_walks.py
+++ b/cayleypy/algo/random_walks.py
@@ -1,6 +1,6 @@
 """Random walks generation for Cayley graphs."""
 
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Union
 
 import numpy as np
 import torch
@@ -34,7 +34,7 @@ class RandomWalksGenerator:
         length=10,
         mode="classic",
         start_state: Union[None, torch.Tensor, np.ndarray, list] = None,
-        nbt_history_depth: Optional[int] = None,
+        nbt_history_depth: int = -1,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Generates random walks on the graph.
 
@@ -68,7 +68,7 @@ class RandomWalksGenerator:
         :param start_state: State from which to start random walk. Defaults to the central state.
         :param mode: Type of random walk (see above). Defaults to "classic".
         :param nbt_history_depth: For "nbt" mode, how many previous levels to remember and ban from revisiting.
-          Defaults to None, which uses ``length`` to retain the full history.
+          Defaults to -1, which uses ``length`` to retain the full history.
         :return: Pair of tensors ``x, y``. ``x`` contains states. ``y[i]`` is the estimated distance from start state
           to state ``x[i]``.
         """
@@ -78,7 +78,7 @@ class RandomWalksGenerator:
         elif mode == "bfs":
             return self.random_walks_bfs(width, length, start_state)
         elif mode == "nbt":
-            if nbt_history_depth is None:
+            if nbt_history_depth == -1:
                 nbt_history_depth = length
             if nbt_history_depth <= 0:
                 raise ValueError("nbt_history_depth must be positive.")

--- a/cayleypy/algo/random_walks.py
+++ b/cayleypy/algo/random_walks.py
@@ -1,6 +1,6 @@
 """Random walks generation for Cayley graphs."""
 
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 import numpy as np
 import torch
@@ -34,7 +34,7 @@ class RandomWalksGenerator:
         length=10,
         mode="classic",
         start_state: Union[None, torch.Tensor, np.ndarray, list] = None,
-        nbt_history_depth: int = 0,
+        nbt_history_depth: Optional[int] = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Generates random walks on the graph.
 
@@ -68,6 +68,7 @@ class RandomWalksGenerator:
         :param start_state: State from which to start random walk. Defaults to the central state.
         :param mode: Type of random walk (see above). Defaults to "classic".
         :param nbt_history_depth: For "nbt" mode, how many previous levels to remember and ban from revisiting.
+          Defaults to None, which uses ``length`` to retain the full history.
         :return: Pair of tensors ``x, y``. ``x`` contains states. ``y[i]`` is the estimated distance from start state
           to state ``x[i]``.
         """
@@ -77,6 +78,11 @@ class RandomWalksGenerator:
         elif mode == "bfs":
             return self.random_walks_bfs(width, length, start_state)
         elif mode == "nbt":
+            if nbt_history_depth is None:
+                nbt_history_depth = length
+            if nbt_history_depth <= 0:
+                raise ValueError("nbt_history_depth must be positive.")
+            nbt_history_depth = min(nbt_history_depth, length)
             return self.random_walks_nbt(width, length, start_state, nbt_history_depth)
         else:
             raise ValueError("Unknown mode:", mode)
@@ -150,7 +156,7 @@ class RandomWalksGenerator:
         return graph.decode_states(torch.vstack(x)), torch.hstack(y)
 
     def random_walks_nbt(
-        self, width: int, length: int, start_state: torch.Tensor, history_depth: int = 0
+        self, width: int, length: int, start_state: torch.Tensor, history_depth: int
     ) -> tuple[torch.Tensor, torch.Tensor]:
         """Generate non-backtracking beam search random walks.
 
@@ -165,6 +171,7 @@ class RandomWalksGenerator:
         :param history_depth: How many previous levels to remember and ban from revisiting.
         :return: Tuple of (states, distances).
         """
+        assert 0 < history_depth <= length
         graph = self.graph
 
         # Initialize current states - duplicate start_state width times.
@@ -179,11 +186,10 @@ class RandomWalksGenerator:
         y[:width] = 0
 
         # Initialize hash storage for non-backtracking.
-        if history_depth > 0:
-            # Use graph's hasher for consistency.
-            initial_hashes = graph.hasher.make_hashes(start_state)
-            vec_hashes_current = initial_hashes.expand(width * graph.definition.n_generators, history_depth).clone()
-            i_cyclic_index_for_hash_storage = 0
+        # Use graph's hasher for consistency.
+        initial_hashes = graph.hasher.make_hashes(start_state)
+        vec_hashes_current = initial_hashes.expand(width * graph.definition.n_generators, history_depth).clone()
+        i_cyclic_index_for_hash_storage = 0
 
         i_step_corrected = 0
         for i_step in range(1, length):
@@ -196,28 +202,27 @@ class RandomWalksGenerator:
                 array_new_states = array_new_states.flatten(end_dim=1)
 
             # 2. Non-backtracking: select states not seen before.
-            if history_depth > 0:
-                # Compute hashes of new states.
-                vec_hashes_new = graph.hasher.make_hashes(array_new_states)
+            # Compute hashes of new states.
+            vec_hashes_new = graph.hasher.make_hashes(array_new_states)
 
-                # Select only states not seen before.
-                mask_new = ~torch.isin(vec_hashes_new, vec_hashes_current.view(-1), assume_unique=False)
-                mask_new_sum = mask_new.sum().item()
+            # Select only states not seen before.
+            mask_new = ~torch.isin(vec_hashes_new, vec_hashes_current.view(-1), assume_unique=False)
+            mask_new_sum = mask_new.sum().item()
 
-                if mask_new_sum >= width:
-                    # Select only new states - not visited before.
-                    array_new_states = array_new_states[mask_new, :]
+            if mask_new_sum >= width:
+                # Select only new states - not visited before.
+                array_new_states = array_new_states[mask_new, :]
+                i_step_corrected += 1
+            else:
+                # Exceptional case: can't find enough new states.
+                # Take as many new states as possible and repeat if needed.
+                if mask_new_sum > 0:
+                    repeat_factor = int(np.ceil(width / mask_new_sum))
+                    array_new_states = array_new_states[mask_new, :].repeat(repeat_factor, 1)[:width, :]
                     i_step_corrected += 1
                 else:
-                    # Exceptional case: can't find enough new states.
-                    # Take as many new states as possible and repeat if needed.
-                    if mask_new_sum > 0:
-                        repeat_factor = int(np.ceil(width / mask_new_sum))
-                        array_new_states = array_new_states[mask_new, :].repeat(repeat_factor, 1)[:width, :]
-                        i_step_corrected += 1
-                    else:
-                        # No new states found, stay in place.
-                        array_new_states = array_current_states
+                    # No new states found, stay in place.
+                    array_new_states = array_current_states
 
             # 3. Select desired number of states randomly.
             perm = torch.randperm(array_new_states.size(0), device=graph.device)
@@ -228,8 +233,7 @@ class RandomWalksGenerator:
             states[i_step * width : (i_step + 1) * width, :] = array_current_states
 
             # 5. Update hash storage.
-            if history_depth > 0:
-                i_cyclic_index_for_hash_storage = (i_cyclic_index_for_hash_storage + 1) % history_depth
-                vec_hashes_current[:, i_cyclic_index_for_hash_storage] = vec_hashes_new
+            i_cyclic_index_for_hash_storage = (i_cyclic_index_for_hash_storage + 1) % history_depth
+            vec_hashes_current[:, i_cyclic_index_for_hash_storage] = vec_hashes_new
 
         return graph.decode_states(states), y

--- a/cayleypy/cayley_graph_test.py
+++ b/cayleypy/cayley_graph_test.py
@@ -10,7 +10,6 @@ from .cayley_graph_def import MatrixGenerator, CayleyGraphDef
 from .datasets import load_dataset
 from .graphs_lib import PermutationGroups, MatrixGroups, prepare_graph
 
-
 RUN_SLOW_TESTS = os.getenv("RUN_SLOW_TESTS") == "1"
 BENCHMARK_RUN = os.getenv("BENCHMARK") == "1"
 
@@ -226,6 +225,33 @@ def test_random_walks_matrix_group():
     assert x.shape == (200, 3, 3)
     assert y.shape == (200,)
     assert np.array_equal(y.cpu().numpy(), [i for i in range(10) for _ in range(20)])
+
+
+def test_random_walks_nbt_matrix_group():
+    generators = [
+        [[49, 1008], [1, 0]],
+        [[0, 1], [1008, 49]],
+        [[0, 583], [964, 49]],
+        [[49, 426], [45, 0]],
+    ]
+    graph = CayleyGraph(
+        CayleyGraphDef.for_matrix_group(
+            generators=[MatrixGenerator.create(matrix, modulo=1009) for matrix in generators],
+            generator_names=["a", "a'", "b", "b'"],
+            central_state=[[1, 0], [0, 1]],
+        ),
+        device="cpu",
+        random_seed=0,
+    )
+    width, length = 1000, 10
+    x, y = graph.random_walks(width=width, length=length, mode="nbt")
+
+    assert x.shape == (width * length, 2, 2)
+    assert y.shape == (width * length,)
+    # Verify that each walk is made of unique states.
+    for i in range(width):
+        walk = x[i::width].reshape(length, -1)
+        assert torch.unique(walk, dim=0).shape[0] == length, f"Walk {i} revisits a state"
 
 
 def test_random_walks_start_state():


### PR DESCRIPTION
* By default, set nbt_history_depth=length so the walks are actually non-backtracking (guaranteed to not have repeats).
* I don't fully understand why we need nbt_history_depth, but I kept it so it behaves as before if supplied by user.
* However, I added check that nbt_history_depth>0, because passing nbt_history_depth=0 doesn't make sense - it means requesting non-backtracking walks but allow repeats at any length.
* Added a test that non-backtracking walks for a matrix group do not have repeats.